### PR TITLE
Fix some hotloading bugs. Add GUI feedback.

### DIFF
--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -1,9 +1,11 @@
+use crate::shader;
 use nannou::prelude::*;
 use nannou::ui::conrod_core::widget_ids;
 use nannou::ui::prelude::*;
+use std::f64::consts::PI;
 
 pub const COLUMN_W: Scalar = 240.0;
-pub const DEFAULT_WIDGET_H: Scalar = 30.0;
+//pub const DEFAULT_WIDGET_H: Scalar = 30.0;
 pub const PAD: Scalar = 20.0;
 pub const WINDOW_WIDTH: u32 = (COLUMN_W + PAD * 2.0) as u32;
 pub const WINDOW_HEIGHT: u32 = 720;
@@ -12,6 +14,8 @@ widget_ids! {
     pub struct Ids {
         background,
         title_text,
+        shader_title_text,
+        shader_state_text,
     }
 }
 
@@ -19,6 +23,8 @@ widget_ids! {
 pub fn update(
     ref mut ui: UiCell,
     ids: &Ids,
+    since_start: std::time::Duration,
+    shader_activity: shader::Activity,
 ) {
     widget::Canvas::new()
         .border(0.0)
@@ -29,6 +35,36 @@ pub fn update(
     text("COHEN GIG")
         .mid_top_of(ids.background)
         .set(ids.title_text, ui);
+
+    text("Shader State")
+        .mid_left_of(ids.background)
+        .down(PAD * 1.5)
+        .set(ids.shader_title_text, ui);
+
+    let (string, color) = match shader_activity {
+        shader::Activity::Incoming => {
+            let s = "Compiling".into();
+            let l = (since_start.secs() * 2.0 * PI).sin() * 0.35 + 0.5;
+            let c = ui::color::YELLOW.with_luminance(l as _);
+            (s, c)
+        },
+        shader::Activity::LastIncoming(last) => match last {
+            shader::LastIncoming::Succeeded => {
+                let s = "Succeeded".into();
+                let c = ui::color::GREEN;
+                (s, c)
+            },
+            shader::LastIncoming::Failed(_err) => {
+                let s = format!("Compilation Failed");
+                let c = ui::color::RED;
+                (s, c)
+            },
+        }
+    };
+    text(&string)
+        .color(color)
+        .down(PAD)
+        .set(ids.shader_state_text, ui);
 }
 
 fn text(s: &str) -> widget::Text {

--- a/cohen_gig/src/shader.rs
+++ b/cohen_gig/src/shader.rs
@@ -1,0 +1,169 @@
+//! Items related to hotloading the shader crate.
+
+use hotlib::BuildError;
+use nannou::prelude::*;
+use shader_shared::Uniforms;
+use std::sync::mpsc;
+
+/// Describes the result of the last incoming library.
+#[derive(Debug)]
+pub enum LastIncoming {
+    Succeeded,
+    Failed(BuildError),
+}
+
+/// The current activity within the shader receiver.
+#[derive(Debug)]
+pub enum Activity<'a> {
+    Incoming,
+    LastIncoming(&'a LastIncoming),
+}
+
+/// A handle for receiving hotloading shader updates on the main thread.
+pub struct ShaderReceiver {
+    // For receiving notification of processing shaders.
+    rx: mpsc::Receiver<Incoming>,
+    // The incoming shader instance if there is one.
+    incoming: Option<Incoming>,
+    // The moment at which the last result was received.
+    last_timestamp: std::time::Instant,
+    // The result of the last incoming shader.
+    last_incoming: LastIncoming,
+}
+
+/// A loaded instance of the shader crate.
+pub struct Shader {
+    // The last successfully loaded shader library instance.
+    lib: hotlib::TempLibrary,
+}
+
+/// The function signature of the shader function.
+pub type ShaderFnPtr = fn(Vector3, &Uniforms) -> LinSrgb;
+
+struct Incoming {
+    rx: mpsc::Receiver<Result<hotlib::TempLibrary, BuildError>>,
+}
+
+impl ShaderReceiver {
+    /// Whether or not the shader is currently incoming. If not, whether the last incoming shader
+    /// built successfully or not.
+    pub fn activity(&self) -> Activity {
+        if self.incoming.is_some() {
+            Activity::Incoming
+        } else {
+            Activity::LastIncoming(&self.last_incoming)
+        }
+    }
+
+    /// The last incoming shader result.
+    pub fn last_incoming(&self) -> &LastIncoming {
+        &self.last_incoming
+    }
+
+    /// The moment at which the last incoming shader result was received, whether success or
+    /// failure.
+    pub fn last_timestamp(&self) -> std::time::Instant {
+        self.last_timestamp
+    }
+
+    /// Update the shader receiver to check for newly received shaders.
+    pub fn update(&mut self) -> Option<Shader> {
+        loop {
+            // If we're already aware of an incoming lib, wait for it.
+            if let Some(ref incoming) = self.incoming {
+                let res = incoming.rx.try_iter().next()?;
+                self.incoming = None;
+                self.last_timestamp = std::time::Instant::now();
+                match res {
+                    Ok(lib) => {
+                        self.last_incoming = LastIncoming::Succeeded;
+                        return Some(Shader::from(lib));
+                    }
+                    Err(err) => {
+                        self.last_incoming = LastIncoming::Failed(err);
+                        return None;
+                    }
+                }
+            }
+
+            // Otherwise check for notification of the most recent incoming shader.
+            self.incoming = Some(self.rx.try_iter().last()?);
+        }
+    }
+}
+
+impl Shader {
+    /// Load the shader function.
+    pub fn get_fn(&self) -> libloading::Symbol<ShaderFnPtr> {
+        unsafe {
+            self.lib.get("shader".as_bytes()).expect("failed to load shader fn symbol")
+        }
+    }
+}
+
+impl From<hotlib::TempLibrary> for Shader {
+    fn from(lib: hotlib::TempLibrary) -> Self {
+        Shader { lib }
+    }
+}
+
+fn shader_toml_path() -> std::path::PathBuf {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_dir = path.parent().expect("could not find workspace dir");
+    workspace_dir.join("shader").join("Cargo").with_extension("toml")
+}
+
+/// Create the shader watch and run it on a separate thread.
+///
+/// Returns the current state of the library and a handle for receiving shader updates.
+pub fn spawn_watch() -> ShaderReceiver {
+    let (incoming_tx, rx) = mpsc::channel();
+
+    // Spawn the shader watch thread.
+    std::thread::spawn(move || {
+        // Begin the watch.
+        let shader_watch = hotlib::watch(&shader_toml_path())
+            .expect("failed to start watching shader");
+
+        fn build_and_send(tx: &mpsc::Sender<Incoming>, pkg: hotlib::Package) {
+            // Notify of incoming library.
+            let (result_tx, rx) = mpsc::channel();
+            tx.send(Incoming { rx }).ok();
+
+            // Attempt to build the library and send the result.
+            let res = pkg.build().map(|build| {
+                build.load().expect("failed to load shader library")
+            });
+            result_tx.send(res).ok();
+        }
+
+        // Initial build.
+        let pkg = shader_watch.package();
+        build_and_send(&incoming_tx, pkg);
+
+        loop {
+            let mut pkg = match shader_watch.next() {
+                Err(hotlib::NextError::ChannelClosed) => break,
+                Err(err) => panic!("{}", err),
+                Ok(pkg) => pkg,
+            };
+            std::thread::sleep(std::time::Duration::from_millis(16));
+            while let Ok(Some(recent_pkg)) = shader_watch.try_next() {
+                pkg = recent_pkg;
+            }
+            build_and_send(&incoming_tx, pkg);
+        }
+    });
+
+    let last_incoming = LastIncoming::Succeeded;
+    let incoming = None;
+    let last_timestamp = std::time::Instant::now();
+    let shader_rx = ShaderReceiver { rx, incoming, last_timestamp, last_incoming };
+    shader_rx
+}
+
+// A function that matches the `ShaderFnPtr` that can be used as a fallback while the dylib is
+// building and loading for the first time.
+pub fn black(_: Vector3, _: &Uniforms) -> LinSrgb {
+    lin_srgb(0.0, 0.0, 0.0)
+}

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -7,4 +7,3 @@
 pub struct Uniforms {
     pub time: f32,
 }
-


### PR DESCRIPTION
This fixes the issues mentioned in #3, including the file watcher
dropouts and the lack of GUI feedback.

The hotloading now occurs asynchronously and the libs are only swapped
out as soon as they're ready and if compilation is successful.