### PR TITLE
Add Vertex type. Replace position arg in shader fn with Vertex.

### DIFF
--- a/cohen_gig/src/shader.rs
+++ b/cohen_gig/src/shader.rs
@@ -2,7 +2,7 @@
 
 use hotlib::BuildError;
 use nannou::prelude::*;
-use shader_shared::Uniforms;
+use shader_shared::{Uniforms, Vertex};
 use std::sync::mpsc;
 
 /// Describes the result of the last incoming library.
@@ -38,7 +38,7 @@ pub struct Shader {
 }
 
 /// The function signature of the shader function.
-pub type ShaderFnPtr = fn(Vector3, &Uniforms, &String) -> LinSrgb;
+pub type ShaderFnPtr = fn(Vertex, &Uniforms, &String) -> LinSrgb;
 
 struct Incoming {
     rx: mpsc::Receiver<Result<hotlib::TempLibrary, BuildError>>,
@@ -164,6 +164,6 @@ pub fn spawn_watch() -> ShaderReceiver {
 
 // A function that matches the `ShaderFnPtr` that can be used as a fallback while the dylib is
 // building and loading for the first time.
-pub fn black(_: Vector3, _: &Uniforms, _: &String) -> LinSrgb {
+pub fn black(_: Vertex, _: &Uniforms, _: &String) -> LinSrgb {
     lin_srgb(0.0, 0.0, 0.0)
 }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -1,7 +1,7 @@
 //! The shader function hotloaded at runtime by the cohen_gig crate.
 
 use nannou::prelude::*;
-use shader_shared::Uniforms;
+use shader_shared::{Uniforms, Vertex};
 
 mod signals;
 mod helpers;
@@ -15,12 +15,13 @@ mod led_shaders;
 mod wash_shaders;
 
 #[no_mangle]
-fn shader(p: Vector3, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
+fn shader(v: Vertex, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
+    let p = v.position;
     match shader_name.as_ref() {
         "SolidHsvColour" => solid_hsv_colour::shader(p, uniforms),
         "SolidRgbColour" => solid_rgb_colour::shader(p, uniforms),
 
-        "AcidGradient" => led_shaders::acid_gradient::shader(p, uniforms),        
+        "AcidGradient" => led_shaders::acid_gradient::shader(p, uniforms),
         "BlinkyCircles" => led_shaders::blinky_circles::shader(p, uniforms),
         "BwGradient" => led_shaders::bw_gradient::shader(p, uniforms),
         "ColourGrid" => led_shaders::colour_grid::shader(p,uniforms),
@@ -44,5 +45,5 @@ fn shader(p: Vector3, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
         _ => lin_srgb(0.0, 0.0, 0.0)
     }
 
-    
+
 }

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -2,11 +2,46 @@
 //! important in order to ensure types are laid out the same way between the dynamic library and
 //! the exe.
 
+use nannou::prelude::*;
+
+/// Attributes unique to each vertex.
+#[derive(Copy, Clone)]
+pub struct Vertex {
+    /// Positioned normalised across the entire venue space.
+    pub position: Point3,
+    /// Information specific to the light fixture type.
+    pub light: Light,
+}
+
+#[derive(Copy, Clone)]
+pub enum Light {
+    /// Wash light info.
+    Wash {
+        /// The index of the light within the layout.
+        index: usize,
+    },
+    /// Single LED light info.
+    Led {
+        /// The index of the LED within all LEDs.
+        index: usize,
+        /// The column and row indices respectively.
+        col_row: [usize; 2],
+        /// The coordinates of the light normalised to the bounds of the LED strips.
+        ///
+        /// - Left edge is -1.0
+        /// - Right edge is 1.0
+        /// - Bottom edge is -1.0
+        /// - Top edge is 1.0
+        normalised_coords: Point2,
+    },
+}
+
+
 /// Data that is uniform across all shader calls for a single frame.
 #[repr(C)]
 pub struct Uniforms {
     pub time: f32,
-    pub resolution: nannou::geom::vector::Vector2,
+    pub resolution: Vector2,
     pub slider1: f32,
     pub slider2: f32,
     pub slider3: f32,


### PR DESCRIPTION
See the comments on the new `Vertex` and `Light` types to see what the
newly available fields provide.

Closes #15.

@JoshuaBatty I haven't updated any of the shaders to use this yet, but
if you do want to you can just pass the vertex as the first argument to
the shader instead of the position.