### PR TITLE
Add Config for persistent data. Add wash and spot DMX addr GUI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+assets/config.json

--- a/cohen_gig/Cargo.toml
+++ b/cohen_gig/Cargo.toml
@@ -12,6 +12,7 @@ libloading = "0.5"
 nannou = "0.11"
 nannou_osc = "0.1"
 sacn = "0.4"
+serde = "1"
 shader_shared = { path = "../shader_shared" }
 korg_nano_kontrol_2 = "0.1.1"
 midir = "0.5"

--- a/cohen_gig/src/conf.rs
+++ b/cohen_gig/src/conf.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Runtime configuration parameters.
+///
+/// These are loaded from `assets/config.json` when the program starts and then saved when the
+/// program closes.
+///
+/// If no `assets/config.json` exists, a default one will be created.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Config {
+    /// Whether or not OSC is enabled.
+    #[serde(default)]
+    pub osc_on: bool,
+    /// Whether or not DMX is enabled.
+    #[serde(default)]
+    pub dmx_on: bool,
+    /// A map from the layout index of each wash to their starting DMX address.
+    #[serde(default = "default::wash_dmx_addrs")]
+    pub wash_dmx_addrs: Box<[u8; crate::layout::WASH_COUNT]>,
+    /// A map from the index of each spotlight to their starting DMX address.
+    #[serde(default = "default::spot_dmx_addrs")]
+    pub spot_dmx_addrs: [u8; crate::SPOT_COUNT]
+}
+
+/// The path to the configuration file.
+pub fn path(assets: &Path) -> PathBuf {
+    assets.join("config.json")
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            osc_on: Default::default(),
+            dmx_on: Default::default(),
+            wash_dmx_addrs: default::wash_dmx_addrs(),
+            spot_dmx_addrs: default::spot_dmx_addrs(),
+        }
+    }
+}
+
+pub mod default {
+    /// The default starting dmx address for each wash light.
+    pub fn wash_dmx_addrs() -> Box<[u8; crate::layout::WASH_COUNT]> {
+        let mut wash_dmx_addrs = Box::new([0; crate::layout::WASH_COUNT]);
+        for (i, w) in wash_dmx_addrs.iter_mut().enumerate() {
+            *w = i as u8 * crate::DMX_ADDRS_PER_WASH;
+        }
+        wash_dmx_addrs
+    }
+
+    /// The default starting dmx address for each spot light.
+    pub fn spot_dmx_addrs() -> [u8; crate::SPOT_COUNT] {
+        let mut spot_dmx_addrs = [0; crate::SPOT_COUNT];
+        let start_addr = crate::layout::WASH_COUNT as u8 * crate::DMX_ADDRS_PER_WASH;
+        for (i, s) in spot_dmx_addrs.iter_mut().enumerate() {
+            *s = start_addr + i as u8 * crate::DMX_ADDRS_PER_SPOT;
+        }
+        spot_dmx_addrs
+    }
+}


### PR DESCRIPTION
This adds a Config type which will be loaded from `assets/config.json`
at the beginning of each session and saved when the program exists
successfully. @JoshuaBatty currently this only moves a couple of the
params from `State` into the new `Config` type, but feel free to move
others that you want to persist between runs! This pretty much behaves
like the `Config` type in our old projects.

This also adds `wash_dmx_addrs` and `spot_dmx_addrs` to the new `Config`
type that allow for mapping each wash and each spot to their starting
DMX addresses via a list of number dialers in the GUI. There are also
two `DMX_ADDRS_PER_WASH/SPOT` constants in the `main.rs` that specify
how many addresses are occupied by each wash/spot respectively.
@JoshuaBatty you can change the `DMX_ADDRS_PER_SPOT` const on the night
if it turns out they use a different number of addresses.

Closes half of #12.

Next up I'll do the DMX universe and address mapping for the LED strips.