### PR TITLE
Implement LED addressing as per #11

### DIFF
--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -369,7 +369,7 @@ pub fn update(
             false => config.spot_dmx_addrs[light_i],
         };
         let min = 0.0;
-        let max = std::u8::MAX as f32;
+        let max = (crate::DMX_ADDRS_PER_UNIVERSE - 1) as f32;
         let precision = 0;
         let dialer = widget::NumberDialer::new(v as f32, min, max, precision)
             .border(0.0)

--- a/cohen_gig/src/layout.rs
+++ b/cohen_gig/src/layout.rs
@@ -38,7 +38,7 @@ pub const TOP_LED_ROW_FROM_GROUND: f32 = BOTTOM_LED_ROW_FROM_GROUND_METRES + LED
 /// The shader origin position in metres.
 pub const SHADER_ORIGIN_METRES: Point2 = Point2 { x: -4.5, y: 12.0 };
 
-/// The height of the LED row from the ground.
+/// The height of the LED row from the ground. Row `0` is at the bottom.
 fn led_row_index_to_height_metres(idx: usize) -> f32 {
     BOTTOM_LED_ROW_FROM_GROUND_METRES + LED_ROW_GAP_METRES * idx as f32
 }
@@ -49,11 +49,13 @@ fn led_row_xs_metres() -> impl Iterator<Item = f32> {
     (0..LEDS_PER_ROW).map(move |ix| x_start + ix as f32 * LED_GAP_METRES)
 }
 
-/// The x and height of every LED in all of the rows, left-most LED of the bottom row.
-pub fn led_positions_metres() -> impl Iterator<Item = (f32, f32)> {
-    (0..LED_ROW_COUNT).flat_map(|ix| {
-        let h = led_row_index_to_height_metres(ix);
-        led_row_xs_metres().map(move |x| (x, h))
+/// The row index, x and height of every LED in all of the rows.
+///
+/// Starts from the left-most LED of the top row.
+pub fn led_positions_metres() -> impl Iterator<Item = (usize, f32, f32)> {
+    (0..LED_ROW_COUNT).rev().flat_map(|row_ix| {
+        let h = led_row_index_to_height_metres(row_ix);
+        led_row_xs_metres().map(move |x| (row_ix, x, h))
     })
 }
 


### PR DESCRIPTION
This implements the LED addressing as described in #11, but with a
starting universe of `LED_START_UNIVERSE` which will be removed in
favour of a dial-able value in a future PR.

@JoshuaBatty this seems to cause some stuttering on my end, do you
notice the same on your machine? Not sure if it's something
unnecessarily slow in the sacn implementation or if this is just how
sending 40+ packets over UDP per frame behaves. Will try do some quick
profiling tomorrow to see if I can see anything, otherwise might have to
try and thread the DMX sending. Getting flashbacks to LATTICE! Hopefully
we can just fork sacn and fix this by setting some flag on the UDP
socket or something.