### PR TITLE
Add a `last_color` field to the Vertex type

### DIFF
--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -613,7 +613,7 @@ fn update(app: &App, model: &mut Model, update: Update) {
     model.uniforms.pot8 = model.uniforms.pot8 * (1.0-model.smoothing_speed) + model.target_pot_values[2] * model.smoothing_speed;
 
     model.uniforms.use_midi = model.config.midi_on;
-    
+
     // Update dimming control of the 2 house spot lights
     model.spot_lights[0] = model.state.spot_light1_fade_to_black;
     model.spot_lights[1] = model.state.spot_light2_fade_to_black;
@@ -641,12 +641,14 @@ fn update(app: &App, model: &mut Model, update: Update) {
         let trg_s = pm_to_ps(trg_m, trg_h);
         let ftb = model.state.wash_fade_to_black;
         let light = Light::Wash { index: wash_ix };
-        let vertex = Vertex { position: trg_s, light };
+        let last_color = model.wash_colors[wash_ix];
+        let position = trg_s;
+        let vertex = Vertex { position, light, last_color };
 
         let left = shader(vertex, &model.uniforms, &model.state.shader_names[model.state.led_shader_idx_left.unwrap()]);
         let right = shader(vertex, &model.uniforms, &model.state.shader_names[model.state.led_shader_idx_right.unwrap()]);
         let colour = shader(vertex, &model.uniforms, &model.state.solid_colour_names[model.state.solid_colour_idx.unwrap()]);
-        
+
         model.wash_colors[wash_ix] = match blend_mode.as_str() {
             "Add" => blend_modes::add(left*xfl, right*xfr) * colour * lin_srgb(ftb,ftb,ftb),
             "Subtract" => blend_modes::subtract(left*xfl, right*xfr) * colour * lin_srgb(ftb,ftb,ftb),
@@ -669,7 +671,9 @@ fn update(app: &App, model: &mut Model, update: Update) {
         let n_y = (row as f32 / (layout::LED_ROW_COUNT - 1) as f32) * 2.0 - 1.0;
         let normalised_coords = vec2(n_x, n_y);
         let light = Light::Led { index, col_row, normalised_coords };
-        let vertex = Vertex { position: ps, light };
+        let last_color = model.led_colors[led_ix];
+        let position = ps;
+        let vertex = Vertex { position, light, last_color };
         let left = shader(vertex, &model.uniforms, &model.state.shader_names[model.state.led_shader_idx_left.unwrap()]);
         let right = shader(vertex, &model.uniforms, &model.state.shader_names[model.state.led_shader_idx_right.unwrap()]);
         let colour = shader(vertex, &model.uniforms, &model.state.solid_colour_names[model.state.solid_colour_idx.unwrap()]);

--- a/shader/src/helpers.rs
+++ b/shader/src/helpers.rs
@@ -59,7 +59,7 @@ pub fn coord_to_hex(coord: Vector2, scale: f32, angle: f32) -> Vector3 {
     let c = multiply_mat2_with_vec2(m, coord);
     let q = (1.0 / 3.0 * 3.0.sqrt() * c.x - 1.0 / 3.0 * c.y) * scale;
     let r = 2.0 / 3.0 * c.y * scale;
-    vec3(q, r, -q - r) 
+    vec3(q, r, -q - r)
 }
 
 pub fn hex_to_cell(hex: Vector3, m: f32) -> Vector3 {
@@ -84,4 +84,11 @@ pub fn hex_to_float(hex: Vector3, amt: f32) -> f32 {
 
 pub fn rand (uv: Vector2) -> f32{
     (uv.dot(vec2(12.9898,78.233)).sin()*43758.5453123).fract()
+}
+
+pub fn lerp_lin_srgb(a: LinSrgb, b: LinSrgb, amt: f32) -> LinSrgb {
+    let r = a.red + (b.red - a.red) * amt;
+    let g = a.green + (b.green - a.green) * amt;
+    let b = a.blue + (b.blue - a.blue) * amt;
+    lin_srgb(r, g, b)
 }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -1,7 +1,7 @@
 //! The shader function hotloaded at runtime by the cohen_gig crate.
 
 use nannou::prelude::*;
-use shader_shared::{Uniforms, Vertex};
+use shader_shared::{Light, Uniforms, Vertex};
 
 mod signals;
 mod helpers;
@@ -17,7 +17,7 @@ mod wash_shaders;
 #[no_mangle]
 fn shader(v: Vertex, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
     let p = v.position;
-    match shader_name.as_ref() {
+    let mut col = match shader_name.as_ref() {
         "SolidHsvColour" => solid_hsv_colour::shader(v, uniforms),
         "SolidRgbColour" => solid_rgb_colour::shader(v, uniforms),
 
@@ -43,7 +43,13 @@ fn shader(v: Vertex, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
         // "MitchWash" => wash_shaders::mitch_wash::shader(v, uniforms),
         // "ColourPalettes" => wash_shaders::colour_palettes::shader(v, uniforms),
         _ => lin_srgb(0.0, 0.0, 0.0)
+    };
+
+    if let Light::Wash { .. } = v.light {
+        // TODO: Make this a slider parameter.
+        let lerp_amt = 1.0;
+        col = crate::helpers::lerp_lin_srgb(v.last_color, col, lerp_amt);
     }
 
-
+    col
 }

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -11,6 +11,8 @@ pub struct Vertex {
     pub position: Point3,
     /// Information specific to the light fixture type.
     pub light: Light,
+    /// The last colour produced by the shader for this vertex.
+    pub last_color: LinSrgb,
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This new field provides the last colour produced by the shader for this
vertex.

Note the current behaviour isn't quite correct as the blending is
occurring outside of the shader. If we can move the blending inside the
shader (e.g. moving the blend mode into the uniforms struct and matching
inside the shader instead) then that should fix this issue.