### PR TITLE
Remove string representations of shaders and blend modes

### DIFF
--- a/cohen_gig/src/conf.rs
+++ b/cohen_gig/src/conf.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use shader_shared::ShaderParams;
+use shader_shared::{BlendMode, Shader, ShaderParams};
 
 /// Runtime configuration parameters.
 ///
@@ -33,16 +33,8 @@ pub struct Config {
     pub led_start_universe: u16,
     #[serde(default)]
     pub fade_to_black: FadeToBlack,
-
     #[serde(default = "default::osc_addr_textbox_string")]
     pub osc_addr_textbox_string: String,
-    #[serde(default = "default::shader_names")]
-    pub shader_names: Vec<String>,
-    #[serde(default = "default::solid_colour_names")]
-    pub solid_colour_names: Vec<String>,
-    #[serde(default = "default::blend_mode_names")]
-    pub blend_mode_names: Vec<String>,
-
     #[serde(default)]
     pub presets: Presets,
 }
@@ -61,18 +53,18 @@ pub struct Presets {
 pub struct Preset {
     #[serde(default)]
     pub name: String,
-    #[serde(default = "default::preset::shader_idx_left")]
-    pub shader_idx_left: usize,
-    #[serde(default = "default::preset::shader_idx_right")]
-    pub shader_idx_right: usize,
+    #[serde(default = "default::preset::shader_left")]
+    pub shader_left: Shader,
+    #[serde(default = "default::preset::shader_right")]
+    pub shader_right: Shader,
+    #[serde(default = "default::preset::colourise")]
+    pub colourise: Shader,
     #[serde(default = "default::preset::left_right_mix")]
     pub left_right_mix: f32,
     #[serde(default = "default::preset::wash_lerp_amt")]
     pub wash_lerp_amt: f32,
-    #[serde(default = "default::preset::solid_colour_idx")]
-    pub solid_colour_idx: usize,
-    #[serde(default = "default::preset::blend_mode_idx")]
-    pub blend_mode_idx: usize,
+    #[serde(default = "default::preset::blend_mode")]
+    pub blend_mode: BlendMode,
     #[serde(default)]
     pub shader_params: ShaderParams,
 }
@@ -119,9 +111,6 @@ impl Default for Config {
             led_start_universe: default::led_start_universe(),
             fade_to_black: Default::default(),
             osc_addr_textbox_string: default::osc_addr_textbox_string(),
-            shader_names: default::shader_names(),
-            solid_colour_names: default::solid_colour_names(),
-            blend_mode_names: default::blend_mode_names(),
             presets: Default::default(),
         }
     }
@@ -152,12 +141,12 @@ impl Default for Preset {
     fn default() -> Self {
         Preset {
             name: default::presets::selected_preset_name(),
-            shader_idx_left: default::preset::shader_idx_left(),
-            shader_idx_right: default::preset::shader_idx_right(),
+            shader_left: default::preset::shader_left(),
+            shader_right: default::preset::shader_right(),
             left_right_mix: default::preset::left_right_mix(),
             wash_lerp_amt: default::preset::wash_lerp_amt(),
-            solid_colour_idx: default::preset::solid_colour_idx(),
-            blend_mode_idx: default::preset::blend_mode_idx(),
+            colourise: default::preset::colourise(),
+            blend_mode: default::preset::blend_mode(),
             shader_params: shader_shared::ShaderParams::default(),
         }
     }
@@ -197,54 +186,6 @@ pub mod default {
         "127.0.0.1:8000".to_string()
     }
 
-    pub fn shader_names() -> Vec<String> {
-        let mut shader_names = Vec::new();
-        shader_names.push("BwGradient".to_string());
-        shader_names.push("EscherTilings".to_string());
-        shader_names.push("JustRelax".to_string());
-        shader_names.push("LineGradient".to_string());
-        shader_names.push("Metafall".to_string());
-        shader_names.push("ParticleZoom".to_string());
-        shader_names.push("RadialLines".to_string());
-        shader_names.push("SquareTunnel".to_string());
-
-        shader_names.push("AcidGradient".to_string());
-        shader_names.push("BlinkyCircles".to_string());
-        shader_names.push("ColourGrid".to_string());
-        shader_names.push("GilmoreAcid".to_string());
-        shader_names.push("LifeLedWall".to_string());
-        shader_names.push("SatisSpiraling".to_string());
-        shader_names.push("SpiralIntersect".to_string());
-        shader_names.push("ThePulse".to_string());
-        shader_names.push("TunnelProjection".to_string());
-        shader_names.push("VertColourGradient".to_string());
-
-        shader_names.push("SolidHsvColour".to_string());
-        shader_names.push("SolidRgbColour".to_string());
-        shader_names.push("ColourPalettes".to_string());
-        shader_names
-    }
-
-    pub fn solid_colour_names() -> Vec<String> {
-        let mut solid_colour_names = Vec::new();
-        solid_colour_names.push("SolidHsvColour".to_string());
-        solid_colour_names.push("SolidRgbColour".to_string());
-        solid_colour_names.push("ColourPalettes".to_string());
-        solid_colour_names
-    }
-
-    pub fn blend_mode_names() -> Vec<String> {
-        let mut blend_mode_names = Vec::new();
-        blend_mode_names.push("Add".to_string());
-        blend_mode_names.push("Subtract".to_string());
-        blend_mode_names.push("Multiply".to_string());
-        blend_mode_names.push("Average".to_string());
-        blend_mode_names.push("Difference".to_string());
-        blend_mode_names.push("Negation".to_string());
-        blend_mode_names.push("Exclusion".to_string());
-        blend_mode_names
-    }
-
     pub mod presets {
         pub fn selected_preset_name() -> String {
             "Empty".to_string()
@@ -258,11 +199,15 @@ pub mod default {
     }
 
     pub mod preset {
-        pub fn shader_idx_left() -> usize {
-            15
+        use shader_shared::{BlendMode, Shader};
+        pub fn shader_left() -> Shader {
+            Shader::SatisSpiraling
         }
-        pub fn shader_idx_right() -> usize {
-            0
+        pub fn shader_right() -> Shader {
+            Shader::SolidHsvColour
+        }
+        pub fn colourise() -> Shader {
+            Shader::SolidHsvColour
         }
         pub fn left_right_mix() -> f32 {
             0.0
@@ -270,11 +215,8 @@ pub mod default {
         pub fn wash_lerp_amt() -> f32 {
             0.5
         }
-        pub fn solid_colour_idx() -> usize {
-            0
-        }
-        pub fn blend_mode_idx() -> usize {
-            0
+        pub fn blend_mode() -> BlendMode {
+            BlendMode::Add
         }
     }
 

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -4,7 +4,7 @@ use nannou::prelude::*;
 use nannou::ui::conrod_core::widget_ids;
 use nannou::ui::prelude::*;
 use nannou::ui::Color;
-use shader_shared::ShaderParams;
+use shader_shared::{BlendMode, Shader, ShaderParams};
 use std::f64::consts::PI;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -527,7 +527,10 @@ pub fn update(
         .color(color::WHITE)
         .set(ids.led_shader_left_text, ui);
 
-    for selected_idx in widget::DropDownList::new(&config.shader_names, Some(preset.shader_idx_left))
+    let shader_names: Vec<_> = shader_shared::ALL_SHADERS.iter().map(|s| s.name()).collect();
+    let shader_idx = preset.shader_left.to_index();
+
+    for selected_idx in widget::DropDownList::new(&shader_names, Some(shader_idx))
         .w_h(COLUMN_W, PAD * 2.0)
         .down(10.0)
         .max_visible_items(15)
@@ -538,33 +541,32 @@ pub fn update(
         .scrollbar_on_top()
         .set(ids.led_shader_left_ddl, ui)
     {
-        preset.shader_idx_left = selected_idx;
+        preset.shader_left = Shader::from_index(selected_idx).unwrap();
     }
 
     let params = &mut preset.shader_params;
-    match config.shader_names[preset.shader_idx_left].as_str() {
-        "AcidGradient" => set_acid_gradient_widgets(ui, &acid_gradient_ids, params),
-        "BlinkyCircles" => set_blinky_circles_widgets(ui, &blinky_circles_ids, params),
-        "BwGradient" => set_bw_gradient_widgets(ui, &bw_gradient_ids, params),
-        "ColourGrid" => set_colour_grid_widgets(ui, &colour_grid_ids, params),
-        "EscherTilings" => set_escher_tilings_widgets(ui, &escher_tilings_ids, params),
-        "GilmoreAcid" => set_gilmore_acid_widgets(ui, &gilmore_acid_ids, params),
-        "JustRelax" => set_just_relax_widgets(ui, &just_relax_ids, params),
-        "LifeLedWall" => set_life_led_wall_widgets(ui, &life_led_wall_ids, params),
-        "LineGradient" => set_line_gradient_widgets(ui, &line_gradient_ids, params),
-        "Metafall" => set_metafall_widgets(ui, &metafall_ids, params),
-        "ParticleZoom" => set_particle_zoom_widgets(ui, &particle_zoom_ids, params),
-        "RadialLines" => set_radial_lines_widgets(ui, &radial_lines_ids, params),
-        "SatisSpiraling" => set_satis_spiraling_widgets(ui, &satis_spiraling_ids, params),
-        "SpiralIntersect" => set_spiral_intersect_widgets(ui, &spiral_intersect_ids, params),
-        "SquareTunnel" => set_square_tunnel_widgets(ui, &square_tunnel_ids, params),
-        "ThePulse" => set_the_pulse_widgets(ui, &the_pulse_ids, params),
-        "TunnelProjection" => set_tunnel_projection_widgets(ui, &tunnel_projection_ids, params),
-        "VertColourGradient" => set_vert_colour_gradient_widgets(ui, &vert_colour_gradient_ids, params),
-        "SolidHsvColour" => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
-        "SolidRgbColour" => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
-        "ColourPalettes" => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
-        _ => (),
+    match preset.shader_left {
+        Shader::AcidGradient => set_acid_gradient_widgets(ui, &acid_gradient_ids, params),
+        Shader::BlinkyCircles => set_blinky_circles_widgets(ui, &blinky_circles_ids, params),
+        Shader::BwGradient => set_bw_gradient_widgets(ui, &bw_gradient_ids, params),
+        Shader::ColourGrid => set_colour_grid_widgets(ui, &colour_grid_ids, params),
+        Shader::EscherTilings => set_escher_tilings_widgets(ui, &escher_tilings_ids, params),
+        Shader::GilmoreAcid => set_gilmore_acid_widgets(ui, &gilmore_acid_ids, params),
+        Shader::JustRelax => set_just_relax_widgets(ui, &just_relax_ids, params),
+        Shader::LifeLedWall => set_life_led_wall_widgets(ui, &life_led_wall_ids, params),
+        Shader::LineGradient => set_line_gradient_widgets(ui, &line_gradient_ids, params),
+        Shader::Metafall => set_metafall_widgets(ui, &metafall_ids, params),
+        Shader::ParticleZoom => set_particle_zoom_widgets(ui, &particle_zoom_ids, params),
+        Shader::RadialLines => set_radial_lines_widgets(ui, &radial_lines_ids, params),
+        Shader::SatisSpiraling => set_satis_spiraling_widgets(ui, &satis_spiraling_ids, params),
+        Shader::SpiralIntersect => set_spiral_intersect_widgets(ui, &spiral_intersect_ids, params),
+        Shader::SquareTunnel => set_square_tunnel_widgets(ui, &square_tunnel_ids, params),
+        Shader::ThePulse => set_the_pulse_widgets(ui, &the_pulse_ids, params),
+        Shader::TunnelProjection => set_tunnel_projection_widgets(ui, &tunnel_projection_ids, params),
+        Shader::VertColourGradient => set_vert_colour_gradient_widgets(ui, &vert_colour_gradient_ids, params),
+        Shader::SolidHsvColour => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
+        Shader::SolidRgbColour => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
+        Shader::ColourPalettes => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
     }
 
     //---------------------- COLOUR POST PROCESS SHADER
@@ -573,7 +575,10 @@ pub fn update(
         .color(color::WHITE)
         .set(ids.colour_post_process_text, ui);
 
-    for selected_idx in widget::DropDownList::new(&config.solid_colour_names, Some(preset.solid_colour_idx))
+    let colour_names: Vec<_> = shader_shared::SOLID_COLOUR_SHADERS.iter().map(|s| s.name()).collect();
+    let colourise_idx = preset.colourise.to_index();
+
+    for selected_idx in widget::DropDownList::new(&colour_names, Some(colourise_idx))
         .w_h(COLUMN_W, PAD * 2.0)
         .down(10.0)
         .max_visible_items(15)
@@ -584,14 +589,14 @@ pub fn update(
         .scrollbar_on_top()
         .set(ids.colour_post_process_ddl, ui)
     {
-        preset.solid_colour_idx = selected_idx;
+        preset.colourise = Shader::from_index(selected_idx).unwrap();
     }
 
-    match config.solid_colour_names[preset.solid_colour_idx].as_str() {
-        "SolidHsvColour" => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
-        "SolidRgbColour" => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
-        "ColourPalettes" => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
-        _ => (),
+    match preset.colourise {
+        Shader::SolidHsvColour => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
+        Shader::SolidRgbColour => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
+        Shader::ColourPalettes => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
+        _ => panic!("unexpected non-colourise shader"),
     }
 
     //---------------------- LED SHADER RIGHT
@@ -601,7 +606,8 @@ pub fn update(
         .color(color::WHITE)
         .set(ids.led_shader_right_text, ui);
 
-    for selected_idx in widget::DropDownList::new(&config.shader_names, Some(preset.shader_idx_right))
+    let shader_idx = preset.shader_right.to_index();
+    for selected_idx in widget::DropDownList::new(&shader_names, Some(shader_idx))
         .w_h(COLUMN_W, PAD * 2.0)
         .down(10.0)
         .max_visible_items(15)
@@ -612,32 +618,31 @@ pub fn update(
         .scrollbar_on_top()
         .set(ids.led_shader_right_ddl, ui)
     {
-        preset.shader_idx_right = selected_idx;
+        preset.shader_right = Shader::from_index(selected_idx).unwrap();
     }
 
-    match config.shader_names[preset.shader_idx_right].as_str() {
-        "AcidGradient" => set_acid_gradient_widgets(ui, &acid_gradient_ids, params),
-        "BlinkyCircles" => set_blinky_circles_widgets(ui, &blinky_circles_ids, params),
-        "BwGradient" => set_bw_gradient_widgets(ui, &bw_gradient_ids, params),
-        "ColourGrid" => set_colour_grid_widgets(ui, &colour_grid_ids, params),
-        "EscherTilings" => set_escher_tilings_widgets(ui, &escher_tilings_ids, params),
-        "GilmoreAcid" => set_gilmore_acid_widgets(ui, &gilmore_acid_ids, params),
-        "JustRelax" => set_just_relax_widgets(ui, &just_relax_ids, params),
-        "LifeLedWall" => set_life_led_wall_widgets(ui, &life_led_wall_ids, params),
-        "LineGradient" => set_line_gradient_widgets(ui, &line_gradient_ids, params),
-        "Metafall" => set_metafall_widgets(ui, &metafall_ids, params),
-        "ParticleZoom" => set_particle_zoom_widgets(ui, &particle_zoom_ids, params),
-        "RadialLines" => set_radial_lines_widgets(ui, &radial_lines_ids, params),
-        "SatisSpiraling" => set_satis_spiraling_widgets(ui, &satis_spiraling_ids, params),
-        "SpiralIntersect" => set_spiral_intersect_widgets(ui, &spiral_intersect_ids, params),
-        "SquareTunnel" => set_square_tunnel_widgets(ui, &square_tunnel_ids, params),
-        "ThePulse" => set_the_pulse_widgets(ui, &the_pulse_ids, params),
-        "TunnelProjection" => set_tunnel_projection_widgets(ui, &tunnel_projection_ids, params),
-        "VertColourGradient" => set_vert_colour_gradient_widgets(ui, &vert_colour_gradient_ids, params),
-        "SolidHsvColour" => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
-        "SolidRgbColour" => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
-        "ColourPalettes" => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
-        _ => (),
+    match preset.shader_right {
+        Shader::AcidGradient => set_acid_gradient_widgets(ui, &acid_gradient_ids, params),
+        Shader::BlinkyCircles => set_blinky_circles_widgets(ui, &blinky_circles_ids, params),
+        Shader::BwGradient => set_bw_gradient_widgets(ui, &bw_gradient_ids, params),
+        Shader::ColourGrid => set_colour_grid_widgets(ui, &colour_grid_ids, params),
+        Shader::EscherTilings => set_escher_tilings_widgets(ui, &escher_tilings_ids, params),
+        Shader::GilmoreAcid => set_gilmore_acid_widgets(ui, &gilmore_acid_ids, params),
+        Shader::JustRelax => set_just_relax_widgets(ui, &just_relax_ids, params),
+        Shader::LifeLedWall => set_life_led_wall_widgets(ui, &life_led_wall_ids, params),
+        Shader::LineGradient => set_line_gradient_widgets(ui, &line_gradient_ids, params),
+        Shader::Metafall => set_metafall_widgets(ui, &metafall_ids, params),
+        Shader::ParticleZoom => set_particle_zoom_widgets(ui, &particle_zoom_ids, params),
+        Shader::RadialLines => set_radial_lines_widgets(ui, &radial_lines_ids, params),
+        Shader::SatisSpiraling => set_satis_spiraling_widgets(ui, &satis_spiraling_ids, params),
+        Shader::SpiralIntersect => set_spiral_intersect_widgets(ui, &spiral_intersect_ids, params),
+        Shader::SquareTunnel => set_square_tunnel_widgets(ui, &square_tunnel_ids, params),
+        Shader::ThePulse => set_the_pulse_widgets(ui, &the_pulse_ids, params),
+        Shader::TunnelProjection => set_tunnel_projection_widgets(ui, &tunnel_projection_ids, params),
+        Shader::VertColourGradient => set_vert_colour_gradient_widgets(ui, &vert_colour_gradient_ids, params),
+        Shader::SolidHsvColour => set_solid_hsv_colour_widgets(ui, &solid_hsv_colour_ids, params),
+        Shader::SolidRgbColour => set_solid_rgb_colour_widgets(ui, &solid_rgb_colour_ids, params),
+        Shader::ColourPalettes => set_colour_palettes_ids_widgets(ui, &colour_palettes_ids, params),
     }
 
     //---------------------- BLEND MODES
@@ -646,7 +651,12 @@ pub fn update(
         .color(color::WHITE)
         .set(ids.blend_mode_text, ui);
 
-    for selected_idx in widget::DropDownList::new(&config.blend_mode_names, Some(preset.blend_mode_idx))
+    let blend_mode_names: Vec<_> = shader_shared::ALL_BLEND_MODES
+        .iter()
+        .map(|blend_mode| blend_mode.name())
+        .collect();
+    let blend_mode_idx = preset.blend_mode as usize;
+    for selected_idx in widget::DropDownList::new(&blend_mode_names, Some(blend_mode_idx))
         .w_h(COLUMN_W, PAD * 2.0)
         .down(10.0)
         .max_visible_items(15)
@@ -657,7 +667,7 @@ pub fn update(
         .scrollbar_on_top()
         .set(ids.blend_mode_ddl, ui)
     {
-        preset.blend_mode_idx = selected_idx;
+        preset.blend_mode = BlendMode::from_index(selected_idx).unwrap();
     }
 
     for value in slider(preset.left_right_mix, 1.0, -1.0)

--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -408,16 +408,12 @@ fn update(app: &App, model: &mut Model, update: Update) {
     let lr_mix = model.config.presets.selected().left_right_mix;
     let xfade_left = (0.5 * (1.0 + lr_mix)).sqrt();
     let xfade_right = (0.5 * (1.0 - lr_mix)).sqrt();
-    let blend_mode = &model.config.blend_mode_names[model.config.presets.selected().blend_mode_idx];
     let preset = model.config.presets.selected();
-    let left_name = &model.config.shader_names[preset.shader_idx_left];
-    let right_name = &model.config.shader_names[preset.shader_idx_right];
-    let colour_name = &model.config.solid_colour_names[preset.solid_colour_idx];
     let mix_info = MixingInfo {
-        left_name: left_name.to_string(),
-        right_name: right_name.to_string(),
-        colour_name: colour_name.to_string(),
-        blend_mode: blend_mode.to_string(),
+        left: preset.shader_left,
+        right: preset.shader_right,
+        colourise: preset.colourise,
+        blend_mode: preset.blend_mode,
         xfade_left,
         xfade_right
     };

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -1,7 +1,7 @@
 //! The shader function hotloaded at runtime by the cohen_gig crate.
 
 use nannou::prelude::*;
-use shader_shared::{Light, Uniforms, Vertex, MixingInfo};
+use shader_shared::{BlendMode, Light, MixingInfo, Shader, Uniforms, Vertex};
 
 mod signals;
 mod helpers;
@@ -18,22 +18,21 @@ mod wash_shaders;
 
 #[no_mangle]
 fn shader(v: Vertex, uniforms: &Uniforms, mix: &MixingInfo) -> LinSrgb {
-    let left = render_shader(v, &uniforms, &mix.left_name);
-    let right = render_shader(v, &uniforms, &mix.right_name);
-    let colour = render_shader(v, &uniforms, &mix.colour_name);
+    let left = render_shader(v, &uniforms, mix.left);
+    let right = render_shader(v, &uniforms, mix.right);
+    let colour = render_shader(v, &uniforms, mix.colourise);
 
     let xfl = lin_srgb(mix.xfade_left,mix.xfade_left,mix.xfade_left);
     let xfr = lin_srgb(mix.xfade_right,mix.xfade_right,mix.xfade_right);
 
-    let mut col = match mix.blend_mode.as_str() {
-        "Add" => blend_modes::add(left*xfl, right*xfr) * colour,
-        "Subtract" => blend_modes::subtract(left*xfl, right*xfr) * colour,
-        "Multiply" => blend_modes::multiply(left, right) * colour,
-        "Average" => blend_modes::average(left*xfl, right*xfr) * colour,
-        "Difference" => blend_modes::difference(left*xfl, right*xfr) * colour,
-        "Negation" => blend_modes::negation(left*xfl, right*xfr) * colour,
-        "Exclusion" => blend_modes::exclusion(left*xfl, right*xfr) * colour,
-        _ => colour,
+    let mut col = match mix.blend_mode {
+        BlendMode::Add => blend_modes::add(left*xfl, right*xfr) * colour,
+        BlendMode::Subtract => blend_modes::subtract(left*xfl, right*xfr) * colour,
+        BlendMode::Multiply => blend_modes::multiply(left, right) * colour,
+        BlendMode::Average => blend_modes::average(left*xfl, right*xfr) * colour,
+        BlendMode::Difference => blend_modes::difference(left*xfl, right*xfr) * colour,
+        BlendMode::Negation => blend_modes::negation(left*xfl, right*xfr) * colour,
+        BlendMode::Exclusion => blend_modes::exclusion(left*xfl, right*xfr) * colour,
     };
 
     if let Light::Wash { .. } = v.light {
@@ -43,33 +42,30 @@ fn shader(v: Vertex, uniforms: &Uniforms, mix: &MixingInfo) -> LinSrgb {
     col
 }
 
-fn render_shader(v: Vertex, uniforms: &Uniforms, shader_name: &String) -> LinSrgb {
+fn render_shader(v: Vertex, uniforms: &Uniforms, shader: Shader) -> LinSrgb {
     let p = v.position;
-    match shader_name.as_ref() {
-        "SolidHsvColour" => solid_hsv_colour::shader(v, uniforms),
-        "SolidRgbColour" => solid_rgb_colour::shader(v, uniforms),
-        "ColourPalettes" => colour_palettes::shader(v, uniforms),
-
-        "AcidGradient" => led_shaders::acid_gradient::shader(v, uniforms),
-        "BlinkyCircles" => led_shaders::blinky_circles::shader(v, uniforms),
-        "BwGradient" => led_shaders::bw_gradient::shader(v, uniforms),
-        "ColourGrid" => led_shaders::colour_grid::shader(v,uniforms),
-        "EscherTilings" => led_shaders::escher_tilings::shader(v, uniforms),
-        "GilmoreAcid" => led_shaders::gilmore_acid::shader(v, uniforms),
-        "JustRelax" => led_shaders::just_relax::shader(v, uniforms),
-        "LifeLedWall" => led_shaders::life_led_wall::shader(v, uniforms),
-        "LineGradient" => led_shaders::line_gradient::shader(v, uniforms),
-        "Metafall" => led_shaders::metafall::shader(v, uniforms),
-        "ParticleZoom" => led_shaders::particle_zoom::shader(v, uniforms),
-        "RadialLines" => led_shaders::radial_lines::shader(v, uniforms),
-        "SatisSpiraling" => led_shaders::satis_spiraling::shader(v, uniforms),
-        "SpiralIntersect" => led_shaders::spiral_intersect::shader(v, uniforms),
-        "SquareTunnel" => led_shaders::square_tunnel::shader(v, uniforms),
-        "ThePulse" => led_shaders::the_pulse::shader(v, uniforms),
-        "TunnelProjection" => led_shaders::tunnel_projection::shader(v, uniforms),
-        "VertColourGradient" => led_shaders::vert_colour_gradient::shader(v, uniforms),
-
-        // "MitchWash" => wash_shaders::mitch_wash::shader(v, uniforms),
+    match shader {
+        Shader::SolidHsvColour => solid_hsv_colour::shader(v, uniforms),
+        Shader::SolidRgbColour => solid_rgb_colour::shader(v, uniforms),
+        Shader::ColourPalettes => colour_palettes::shader(v, uniforms),
+        Shader::AcidGradient => led_shaders::acid_gradient::shader(v, uniforms),
+        Shader::BlinkyCircles => led_shaders::blinky_circles::shader(v, uniforms),
+        Shader::BwGradient => led_shaders::bw_gradient::shader(v, uniforms),
+        Shader::ColourGrid => led_shaders::colour_grid::shader(v,uniforms),
+        Shader::EscherTilings => led_shaders::escher_tilings::shader(v, uniforms),
+        Shader::GilmoreAcid => led_shaders::gilmore_acid::shader(v, uniforms),
+        Shader::JustRelax => led_shaders::just_relax::shader(v, uniforms),
+        Shader::LifeLedWall => led_shaders::life_led_wall::shader(v, uniforms),
+        Shader::LineGradient => led_shaders::line_gradient::shader(v, uniforms),
+        Shader::Metafall => led_shaders::metafall::shader(v, uniforms),
+        Shader::ParticleZoom => led_shaders::particle_zoom::shader(v, uniforms),
+        Shader::RadialLines => led_shaders::radial_lines::shader(v, uniforms),
+        Shader::SatisSpiraling => led_shaders::satis_spiraling::shader(v, uniforms),
+        Shader::SpiralIntersect => led_shaders::spiral_intersect::shader(v, uniforms),
+        Shader::SquareTunnel => led_shaders::square_tunnel::shader(v, uniforms),
+        Shader::ThePulse => led_shaders::the_pulse::shader(v, uniforms),
+        Shader::TunnelProjection => led_shaders::tunnel_projection::shader(v, uniforms),
+        Shader::VertColourGradient => led_shaders::vert_colour_gradient::shader(v, uniforms),
         _ => lin_srgb(0.0, 0.0, 0.0)
     }
 }

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -18,10 +18,10 @@ pub struct Vertex {
 
 #[derive(Clone)]
 pub struct MixingInfo {
-    pub left_name: String,
-    pub right_name: String,
-    pub colour_name: String,
-    pub blend_mode: String,
+    pub left: Shader,
+    pub right: Shader,
+    pub colourise: Shader,
+    pub blend_mode: BlendMode,
     /// x fade left amount
     pub xfade_left: f32,
     /// x fade right amount
@@ -115,6 +115,44 @@ pub struct ShaderParams {
     pub solid_rgb_colour: SolidRgbColour,
     #[serde(default)]
     pub colour_palettes: ColourPalettes,
+}
+
+/// Refers to the selected blend mode type for a preset.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum BlendMode {
+    Add,
+    Subtract,
+    Multiply,
+    Average,
+    Difference,
+    Negation,
+    Exclusion,
+}
+
+/// For selecting between each of the available shaders at runtime.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Shader {
+    SolidHsvColour,
+    SolidRgbColour,
+    ColourPalettes,
+    AcidGradient,
+    BlinkyCircles,
+    BwGradient,
+    ColourGrid,
+    EscherTilings,
+    GilmoreAcid,
+    JustRelax,
+    LifeLedWall,
+    LineGradient,
+    Metafall,
+    ParticleZoom,
+    RadialLines,
+    SatisSpiraling,
+    SpiralIntersect,
+    SquareTunnel,
+    ThePulse,
+    TunnelProjection,
+    VertColourGradient,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -371,6 +409,170 @@ pub struct ColourPalettes {
     pub interval: f32,
     #[serde(default = "default::colour_palettes::selected")]
     pub selected: usize,
+}
+
+pub const ALL_BLEND_MODES: &'static [BlendMode] = &[
+    BlendMode::Add,
+    BlendMode::Subtract,
+    BlendMode::Multiply,
+    BlendMode::Average,
+    BlendMode::Difference,
+    BlendMode::Negation,
+    BlendMode::Exclusion,
+];
+
+pub const ALL_SHADERS: &'static [Shader] = &[
+    Shader::SolidHsvColour,
+    Shader::SolidRgbColour,
+    Shader::ColourPalettes,
+    Shader::AcidGradient,
+    Shader::BlinkyCircles,
+    Shader::BwGradient,
+    Shader::ColourGrid,
+    Shader::EscherTilings,
+    Shader::GilmoreAcid,
+    Shader::JustRelax,
+    Shader::LifeLedWall,
+    Shader::LineGradient,
+    Shader::Metafall,
+    Shader::ParticleZoom,
+    Shader::RadialLines,
+    Shader::SatisSpiraling,
+    Shader::SpiralIntersect,
+    Shader::SquareTunnel,
+    Shader::ThePulse,
+    Shader::TunnelProjection,
+    Shader::VertColourGradient,
+];
+
+pub const SOLID_COLOUR_SHADERS: &'static [Shader] = &[
+    Shader::SolidHsvColour,
+    Shader::SolidRgbColour,
+    Shader::ColourPalettes,
+];
+
+impl BlendMode {
+    /// The name of the variant in the form of a string for GUI presentation.
+    pub fn name(&self) -> &str {
+        match *self {
+            BlendMode::Add => "Add",
+            BlendMode::Subtract => "Subtract",
+            BlendMode::Multiply => "Multiply",
+            BlendMode::Average => "Average",
+            BlendMode::Difference => "Difference",
+            BlendMode::Negation => "Negation",
+            BlendMode::Exclusion => "Exclusion",
+        }
+    }
+
+    pub fn to_index(&self) -> usize {
+        match *self {
+            BlendMode::Add => 0,
+            BlendMode::Subtract => 1,
+            BlendMode::Multiply => 2,
+            BlendMode::Average => 3,
+            BlendMode::Difference => 4,
+            BlendMode::Negation => 5,
+            BlendMode::Exclusion => 6,
+        }
+    }
+
+    pub fn from_index(index: usize) -> Option<Self> {
+        let mode = match index {
+            0 => BlendMode::Add,
+            1 => BlendMode::Subtract,
+            2 => BlendMode::Multiply,
+            3 => BlendMode::Average,
+            4 => BlendMode::Difference,
+            5 => BlendMode::Negation,
+            6 => BlendMode::Exclusion,
+            _ => return None,
+        };
+        Some(mode)
+    }
+}
+
+impl Shader {
+    /// The name of the variant in the form of a string for GUI presentation.
+    pub fn name(&self) -> &str {
+        match *self {
+            Shader::SolidHsvColour => "SolidHsvColour",
+            Shader::SolidRgbColour => "SolidRgbColour",
+            Shader::ColourPalettes => "ColourPalettes",
+            Shader::AcidGradient => "AcidGradient",
+            Shader::BlinkyCircles => "BlinkyCircles",
+            Shader::BwGradient => "BwGradient",
+            Shader::ColourGrid => "ColourGrid",
+            Shader::EscherTilings => "EscherTilings",
+            Shader::GilmoreAcid => "GilmoreAcid",
+            Shader::JustRelax => "JustRelax",
+            Shader::LifeLedWall => "LifeLedWall",
+            Shader::LineGradient => "LineGradient",
+            Shader::Metafall => "Metafall",
+            Shader::ParticleZoom => "ParticleZoom",
+            Shader::RadialLines => "RadialLines",
+            Shader::SatisSpiraling => "SatisSpiraling",
+            Shader::SpiralIntersect => "SpiralIntersect",
+            Shader::SquareTunnel => "SquareTunnel",
+            Shader::ThePulse => "ThePulse",
+            Shader::TunnelProjection => "TunnelProjection",
+            Shader::VertColourGradient => "VertColourGradient",
+        }
+    }
+
+    pub fn to_index(&self) -> usize {
+        match *self {
+            Shader::SolidHsvColour => 0,
+            Shader::SolidRgbColour => 1,
+            Shader::ColourPalettes => 2,
+            Shader::AcidGradient => 3,
+            Shader::BlinkyCircles => 4,
+            Shader::BwGradient => 5,
+            Shader::ColourGrid => 6,
+            Shader::EscherTilings => 7,
+            Shader::GilmoreAcid => 8,
+            Shader::JustRelax => 9,
+            Shader::LifeLedWall => 10,
+            Shader::LineGradient => 11,
+            Shader::Metafall => 12,
+            Shader::ParticleZoom => 13,
+            Shader::RadialLines => 14,
+            Shader::SatisSpiraling => 15,
+            Shader::SpiralIntersect => 16,
+            Shader::SquareTunnel => 17,
+            Shader::ThePulse => 18,
+            Shader::TunnelProjection => 19,
+            Shader::VertColourGradient => 20,
+        }
+    }
+
+    pub fn from_index(index: usize) -> Option<Self> {
+        let shader = match index {
+            0 => Shader::SolidHsvColour,
+            1 => Shader::SolidRgbColour,
+            2 => Shader::ColourPalettes,
+            3 => Shader::AcidGradient,
+            4 => Shader::BlinkyCircles,
+            5 => Shader::BwGradient,
+            6 => Shader::ColourGrid,
+            7 => Shader::EscherTilings,
+            8 => Shader::GilmoreAcid,
+            9 => Shader::JustRelax,
+            10 => Shader::LifeLedWall,
+            11 => Shader::LineGradient,
+            12 => Shader::Metafall,
+            13 => Shader::ParticleZoom,
+            14 => Shader::RadialLines,
+            15 => Shader::SatisSpiraling,
+            16 => Shader::SpiralIntersect,
+            17 => Shader::SquareTunnel,
+            18 => Shader::ThePulse,
+            19 => Shader::TunnelProjection,
+            20 => Shader::VertColourGradient,
+            _ => return None,
+        };
+        Some(shader)
+    }
 }
 
 impl Default for AcidGradient {


### PR DESCRIPTION
Switches to use an enum for shader and blend mode selection, each with
methods for providing a static str and indices for GUI display and
listing.