### PR TITLE
Make button state available to shaders via `uniforms.buttons`.

### DIFF
--- a/shader_shared/Cargo.toml
+++ b/shader_shared/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+korg_nano_kontrol_2 = "0.1"
 nannou = "0.11"
 serde = "1"

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -2,8 +2,10 @@
 //! important in order to ensure types are laid out the same way between the dynamic library and
 //! the exe.
 
+use korg_nano_kontrol_2::{ButtonRow, MarkerButton, Strip, State, TrackButton, Transport};
 use nannou::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Attributes unique to each vertex.
 #[derive(Copy, Clone)]
@@ -58,6 +60,26 @@ pub struct Uniforms {
     pub params: ShaderParams,
     pub wash_lerp_amt: f32,
     pub mix: MixingInfo,
+    /// Only contains buttons that have been pressed at least once.
+    pub buttons: HashMap<Button, ButtonState>,
+}
+
+/// Describes one of the buttons on the korg.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Button {
+    Row(ButtonRow, Strip),
+    Track(TrackButton),
+    Cycle,
+    Marker(MarkerButton),
+    Transport(Transport),
+}
+
+/// The state of a button that has been interacted with.
+pub struct ButtonState {
+    /// Seconds since the button was pressed.
+    pub secs: f32,
+    /// The current state of the button (on or off).
+    pub state: State,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
The uniforms struct now contains a map from buttons to their current state, including whether or not they are currently on or off and how long it has been since an "on" event was last received.

Here's an example that might sum on a glowing colour in a short burst each time the button is pressed:

```rust
if let Some(state) = uniforms.buttons.get(&Button::Cycle) {
    let env = (1.0 - state.secs).max(0.0).powf(2.0); // create a quick, one second "pulse"-like transient envelope.
    col += glow * env;
}
```

@JoshuaBatty no wukkaz if you have no time to integrate this, just thought I'd include it since the branch was sitting here almost done in case you're feeling inspired to mess with it!