### PR TITLE
Commit config with presets. Add shader and preset with button demo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
-assets/config.json

--- a/assets/config.json
+++ b/assets/config.json
@@ -1,0 +1,1048 @@
+{
+  "osc_on": false,
+  "dmx_on": false,
+  "midi_on": false,
+  "wash_dmx_addrs": [
+    0,
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    36,
+    40,
+    44,
+    48,
+    52,
+    56,
+    60,
+    64,
+    68,
+    72,
+    76,
+    80,
+    84,
+    88,
+    92,
+    96,
+    100,
+    104,
+    108
+  ],
+  "spot_dmx_addrs": [
+    112,
+    113
+  ],
+  "wash_spot_universe": 1,
+  "led_start_universe": 2,
+  "fade_to_black": {
+    "led": 1.0,
+    "wash": 1.0,
+    "spot1": 1.0,
+    "spot2": 1.0
+  },
+  "osc_addr_textbox_string": "127.0.0.1:8000",
+  "presets": {
+    "selected_preset_name": "Spatial Wash (Press space / cycle)",
+    "selected_preset_idx": 6,
+    "list": [
+      {
+        "name": "Pulse Gradient",
+        "shader_left": "ThePulse",
+        "shader_right": "AcidGradient",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 0.07344514,
+        "wash_lerp_amt": 0.056288775,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Satis Relaxation",
+        "shader_left": "SatisSpiraling",
+        "shader_right": "JustRelax",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 0.0,
+        "wash_lerp_amt": 0.07228645,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Gilmore Spiraling",
+        "shader_left": "GilmoreAcid",
+        "shader_right": "SatisSpiraling",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 0.06780499,
+        "wash_lerp_amt": 0.056473553,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.013354747,
+            "density": 0.01,
+            "shape": 0.14589004,
+            "tau": 0.4180888
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Magenta Mirror Gradient",
+        "shader_left": "BwGradient",
+        "shader_right": "BwGradient",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 0.0,
+        "wash_lerp_amt": 1.0,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.04589564,
+            "dc": 0.05,
+            "amp": 0.5048485,
+            "freq": 0.5,
+            "mirror": true
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 0.9473315,
+            "saturation": 0.6780581,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Monochrome Escher Shifts",
+        "shader_left": "EscherTilings",
+        "shader_right": "SolidHsvColour",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 1.0,
+        "wash_lerp_amt": 0.040208198,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.14051183,
+            "scale": 0.118715666,
+            "shape_iter": 0.21841711
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Slow Tunnel Projection",
+        "shader_left": "TunnelProjection",
+        "shader_right": "SolidHsvColour",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 1.0,
+        "wash_lerp_amt": 0.5,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.09935735,
+            "res": 0.40345585
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.026027171,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      },
+      {
+        "name": "Spatial Wash (Press space / cycle)",
+        "shader_left": "MitchWash",
+        "shader_right": "SolidHsvColour",
+        "colourise": "SolidHsvColour",
+        "left_right_mix": 1.0,
+        "wash_lerp_amt": 0.5,
+        "blend_mode": "Add",
+        "shader_params": {
+          "acid_gradient": {
+            "speed": 0.5125,
+            "zoom": 0.0,
+            "offset": 0.75
+          },
+          "blinky_circles": {
+            "speed": 0.5125,
+            "zoom": 0.05,
+            "offset": 0.25
+          },
+          "bw_gradient": {
+            "speed": 0.5125,
+            "dc": 0.05,
+            "amp": 0.5,
+            "freq": 0.5,
+            "mirror": false
+          },
+          "colour_grid": {
+            "speed": 0.5,
+            "zoom_amount": 0.1
+          },
+          "escher_tilings": {
+            "speed": 0.2,
+            "scale": 0.2,
+            "shape_iter": 0.2
+          },
+          "gilmore_acid": {
+            "speed": 0.025,
+            "displace": 0.01,
+            "colour_offset": 0.85,
+            "grid_size": 0.345,
+            "wave": 0.088,
+            "zoom_amount": 0.0,
+            "rotation_amount": 0.0,
+            "brightness": 1.0,
+            "saturation": 0.15
+          },
+          "just_relax": {
+            "speed": 0.6,
+            "shape_offset": 0.728,
+            "iter": 1.0
+          },
+          "life_led_wall": {
+            "speed": 0.25,
+            "size": 0.73,
+            "red": 0.5,
+            "green": 0.2,
+            "blue": 0.1,
+            "saturation": 1.0,
+            "colour_offset": 0.01
+          },
+          "line_gradient": {
+            "speed": 0.03,
+            "num_stripes": 1.0,
+            "stripe_width": 0.9,
+            "angle": 0.5,
+            "smooth_width": 0.155
+          },
+          "metafall": {
+            "speed": 0.47,
+            "scale": 0.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "particle_zoom": {
+            "speed": 0.01,
+            "density": 0.01,
+            "shape": 0.35,
+            "tau": 1.0
+          },
+          "radial_lines": {
+            "speed": 0.05,
+            "zoom_amount": 0.8
+          },
+          "satis_spiraling": {
+            "speed": 0.5,
+            "loops": 0.8,
+            "mirror": true,
+            "rotate": true
+          },
+          "spiral_intersect": {
+            "speed": 0.02,
+            "g1": 0.4,
+            "g2": 0.6,
+            "rot1": 1.0,
+            "rot2": 0.5,
+            "colours": 1.0
+          },
+          "square_tunnel": {
+            "speed": 0.6,
+            "rotation_speed": 0.025,
+            "rotation_offset": 0.0,
+            "zoom": 0.8
+          },
+          "the_pulse": {
+            "speed": 0.08,
+            "scale": 0.1,
+            "colour_iter": 0.25,
+            "thickness": 0.0
+          },
+          "tunnel_projection": {
+            "speed": 0.5,
+            "res": 0.5
+          },
+          "vert_colour_gradient": {
+            "speed": 0.5,
+            "scale": 0.83,
+            "colour_iter": 0.015,
+            "line_amp": 0.0,
+            "diag_amp": 0.0,
+            "boarder_amp": 0.65
+          },
+          "solid_hsv_colour": {
+            "hue": 1.0,
+            "saturation": 0.0,
+            "value": 1.0
+          },
+          "solid_rgb_colour": {
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0
+          },
+          "colour_palettes": {
+            "speed": 0.1,
+            "interval": 0.05,
+            "selected": 0
+          },
+          "mitch_wash": {
+            "speed": 1.0
+          }
+        }
+      }
+    ]
+  }
+}

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -382,6 +382,18 @@ impl Params for shader_shared::VertColourGradient {
     }
 }
 
+impl Params for shader_shared::MitchWash {
+    fn param_count(&self) -> usize {
+        1
+    }
+    fn param_mut(&mut self, ix: usize) -> ParamMut {
+        match ix {
+            0 => ParamMut { name: "speed", kind: ParamKindMut::F32 { value: &mut self.speed, max: 1.0 } },
+            _ => panic!("no parameter for index {}: check `param_count` impl", ix),
+        }
+    }
+}
+
 impl Params for shader_shared::SolidHsvColour {
     fn param_count(&self) -> usize {
         3
@@ -1083,5 +1095,6 @@ fn shader_params(shader: Shader, params: &mut ShaderParams) -> &mut dyn Params {
         Shader::SolidHsvColour => &mut params.solid_hsv_colour,
         Shader::SolidRgbColour => &mut params.solid_rgb_colour,
         Shader::ColourPalettes => &mut params.colour_palettes,
+        Shader::MitchWash => &mut params.mitch_wash,
     }
 }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -79,5 +79,6 @@ fn get_shader(shader: Shader) -> fn(Vertex, &Uniforms) -> LinSrgb {
         Shader::ThePulse => led_shaders::the_pulse::shader,
         Shader::TunnelProjection => led_shaders::tunnel_projection::shader,
         Shader::VertColourGradient => led_shaders::vert_colour_gradient::shader,
+        Shader::MitchWash => wash_shaders::mitch_wash::shader,
     }
 }

--- a/shader/src/wash_shaders/mitch_wash.rs
+++ b/shader/src/wash_shaders/mitch_wash.rs
@@ -1,5 +1,5 @@
 use nannou::prelude::*;
-use shader_shared::{Uniforms, Vertex, Light};
+use shader_shared::{Button, Uniforms, Vertex, Light};
 
 use crate::helpers::*;
 
@@ -8,16 +8,23 @@ struct Params {
 }
 
 pub fn shader(v: Vertex , uniforms: &Uniforms) -> LinSrgb {
-    let params = Params {
-        speed: 0.5,
-    };
-
+    let speed = uniforms.params.mitch_wash.speed;
     let p = v.position;
-
-    let t = uniforms.time * params.speed;
+    let t = uniforms.time * speed;
     let b = (p.z + t).sin() * 0.5 + 0.5;
     let r = (p.x + t * 2.0 * p.x.signum()).cos() * 0.5 + 0.5;
     let g = (p.y + t).cos() * 0.5 + 0.5;
-    let col = vec3(b*r*0.5, g*b, b);
+    let mut col = vec3(b*r*0.5, g*b, b);
+
+    // Add a burst of light emanating from the led wall down the venue on cycle press.
+    if let Some(state) = uniforms.buttons.get(&Button::Cycle) {
+        let env = (1.0 - state.secs).max(0.0).powf(2.0);
+        let m = p.magnitude();
+        let dist = (m - state.secs * 4.0).abs();
+        let l = (1.0 - dist * 2.0).max(0.0);
+        let glow = l * env;
+        col += vec3(1.0, 1.0, 1.0) * glow;
+    }
+
     lin_srgb(col.x, col.y, col.z)
 }

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -138,6 +138,8 @@ pub struct ShaderParams {
     pub solid_rgb_colour: SolidRgbColour,
     #[serde(default)]
     pub colour_palettes: ColourPalettes,
+    #[serde(default)]
+    pub mitch_wash: MitchWash,
 }
 
 /// Refers to the selected blend mode type for a preset.
@@ -176,6 +178,7 @@ pub enum Shader {
     ThePulse,
     TunnelProjection,
     VertColourGradient,
+    MitchWash,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -405,6 +408,11 @@ pub struct VertColourGradient {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MitchWash {
+    pub speed: f32,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SolidHsvColour {
     #[serde(default = "default::solid_hsv_colour::hue")]
     pub hue: f32,
@@ -466,6 +474,7 @@ pub const ALL_SHADERS: &'static [Shader] = &[
     Shader::ThePulse,
     Shader::TunnelProjection,
     Shader::VertColourGradient,
+    Shader::MitchWash,
 ];
 
 pub const SOLID_COLOUR_SHADERS: &'static [Shader] = &[
@@ -540,6 +549,7 @@ impl Shader {
             Shader::ThePulse => "ThePulse",
             Shader::TunnelProjection => "TunnelProjection",
             Shader::VertColourGradient => "VertColourGradient",
+            Shader::MitchWash => "MitchWash",
         }
     }
 
@@ -566,6 +576,7 @@ impl Shader {
             Shader::ThePulse => 18,
             Shader::TunnelProjection => 19,
             Shader::VertColourGradient => 20,
+            Shader::MitchWash => 21,
         }
     }
 
@@ -592,6 +603,7 @@ impl Shader {
             18 => Shader::ThePulse,
             19 => Shader::TunnelProjection,
             20 => Shader::VertColourGradient,
+            21 => Shader::MitchWash,
             _ => return None,
         };
         Some(shader)
@@ -797,6 +809,14 @@ impl Default for VertColourGradient {
             line_amp: default::vert_colour_gradient::line_amp(),
             diag_amp: default::vert_colour_gradient::diag_amp(),
             boarder_amp: default::vert_colour_gradient::boarder_amp(),
+        }
+    }
+}
+
+impl Default for MitchWash {
+    fn default() -> Self {
+        MitchWash {
+            speed: default::mitch_wash::speed(),
         }
     }
 }
@@ -1115,6 +1135,12 @@ pub mod default {
         }
         pub fn boarder_amp() -> f32 {
             0.65
+        }
+    }
+
+    pub mod mitch_wash {
+        pub fn speed() -> f32 {
+            1.0
         }
     }
 


### PR DESCRIPTION
This commit includes the config.json into the gitignore so that we can
start committing presets. I've added 6 or 7 presets to kick things off,
but feel free to rename/remove them or whatevs if you have a flow in
mind for the night!

This also re-adds in the original wash test shader I added and uses it
to demonstrate the affect of button presses. You can trigger the radial
glow burst effect by pressing the cycle button on the korg (or spacebar
which pretends to be the cycle button). This is just to give an idea of
how it can potentially spice up the shaders a bit and add a bit of
musical/spatial interactivity :+1: