### PR TITLE
Add light pattern generator LED shader

### DIFF
--- a/assets/presets.json
+++ b/assets/presets.json
@@ -1,6 +1,6 @@
 {
-  "selected_preset_name": "Gilmore Spiraling",
-  "selected_preset_idx": 2,
+  "selected_preset_name": "Butterflies",
+  "selected_preset_idx": 51,
   "list": [
     {
       "name": "Pulse Gradient",
@@ -48,6 +48,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -61,6 +74,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -198,6 +215,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -211,6 +241,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -348,6 +382,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -361,6 +408,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -522,6 +573,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -535,6 +599,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -672,6 +740,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -685,6 +766,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -822,6 +907,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -835,6 +933,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -995,6 +1097,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1008,6 +1123,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1145,6 +1264,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1158,6 +1290,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1295,6 +1431,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1308,6 +1457,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1474,6 +1627,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1487,6 +1653,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1624,6 +1794,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1637,6 +1820,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1774,6 +1961,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1787,6 +1987,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -1949,6 +2153,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -1962,6 +2179,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2099,6 +2320,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2112,6 +2346,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2249,6 +2487,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2262,6 +2513,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2422,6 +2677,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2435,6 +2703,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2572,6 +2844,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2585,6 +2870,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2722,6 +3011,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2735,6 +3037,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -2895,6 +3201,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -2908,6 +3227,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3045,6 +3368,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3058,6 +3394,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3195,6 +3535,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3208,6 +3561,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3367,6 +3724,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3380,6 +3750,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3517,6 +3891,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3530,6 +3917,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3667,6 +4058,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3680,6 +4084,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3841,6 +4249,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -3854,6 +4275,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -3991,6 +4416,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4004,6 +4442,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4141,6 +4583,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4154,6 +4609,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4315,6 +4774,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4328,6 +4800,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4465,6 +4941,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4478,6 +4967,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4615,6 +5108,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4628,6 +5134,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4788,6 +5298,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4801,6 +5324,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -4938,6 +5465,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -4951,6 +5491,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5088,6 +5632,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5101,6 +5658,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5261,6 +5822,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5274,6 +5848,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5411,6 +5989,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5424,6 +6015,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5561,6 +6156,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5574,6 +6182,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5734,6 +6346,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5747,6 +6372,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -5884,6 +6513,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -5897,6 +6539,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6034,6 +6680,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6047,6 +6706,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6209,6 +6872,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6222,6 +6898,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6359,6 +7039,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6372,6 +7065,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6509,6 +7206,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6522,6 +7232,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6682,6 +7396,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6695,6 +7422,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6832,6 +7563,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6845,6 +7589,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -6982,6 +7730,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -6995,6 +7756,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7159,6 +7924,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7172,6 +7950,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7309,6 +8091,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7322,6 +8117,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7459,6 +8258,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7472,6 +8284,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7635,6 +8451,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7648,6 +8477,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7785,6 +8618,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7798,6 +8644,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -7935,6 +8785,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -7948,6 +8811,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8110,6 +8977,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8123,6 +9003,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8260,6 +9144,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8273,6 +9170,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8410,6 +9311,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8423,6 +9337,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8589,6 +9507,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8602,6 +9533,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8739,6 +9674,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8752,6 +9700,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -8889,6 +9841,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -8902,6 +9867,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9068,6 +10037,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9081,6 +10063,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9218,6 +10204,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9231,6 +10230,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9368,6 +10371,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9381,6 +10397,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9541,6 +10561,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9554,6 +10587,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9691,6 +10728,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9704,6 +10754,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -9841,6 +10895,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -9854,6 +10921,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10014,6 +11085,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10027,6 +11111,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10164,6 +11252,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10177,6 +11278,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10314,6 +11419,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10327,6 +11445,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10489,6 +11611,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10502,6 +11637,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10639,6 +11778,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10652,6 +11804,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10789,6 +11945,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10802,6 +11971,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -10964,6 +12137,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -10977,6 +12163,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11114,6 +12304,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11127,6 +12330,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11264,6 +12471,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11277,6 +12497,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11439,6 +12663,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11452,6 +12689,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11589,6 +12830,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11602,6 +12856,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11739,6 +12997,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11752,6 +13023,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -11911,6 +13186,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -11924,6 +13212,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12061,6 +13353,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12074,6 +13379,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12211,6 +13520,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12224,6 +13546,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12385,6 +13711,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12398,6 +13737,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12535,6 +13878,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12548,6 +13904,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12685,6 +14045,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12698,6 +14071,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -12856,6 +14233,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -12869,6 +14259,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13006,6 +14400,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13019,6 +14426,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13156,6 +14567,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13169,6 +14593,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13329,6 +14757,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13342,6 +14783,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13479,6 +14924,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13492,6 +14950,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13629,6 +15091,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13642,6 +15117,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13803,6 +15282,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13816,6 +15308,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -13953,6 +15449,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -13966,6 +15475,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14103,6 +15616,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14116,6 +15642,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14277,6 +15807,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14290,6 +15833,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14427,6 +15974,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14440,6 +16000,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14577,6 +16141,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14590,6 +16167,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14751,6 +16332,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14764,6 +16358,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -14901,6 +16499,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -14914,6 +16525,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15051,6 +16666,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15064,6 +16692,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15225,6 +16857,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15238,6 +16883,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15375,6 +17024,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15388,6 +17050,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15525,6 +17191,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15538,6 +17217,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15703,6 +17386,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15716,6 +17412,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -15853,6 +17553,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -15866,6 +17579,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16003,6 +17720,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16016,6 +17746,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16181,6 +17915,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16194,6 +17941,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16331,6 +18082,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16344,6 +18108,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16481,6 +18249,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16494,6 +18275,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16657,6 +18442,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16670,6 +18468,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16807,6 +18609,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16820,6 +18635,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -16957,6 +18776,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -16970,6 +18802,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17129,6 +18965,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17142,6 +18991,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17279,6 +19132,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17292,6 +19158,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17429,6 +19299,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17442,6 +19325,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17601,6 +19488,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17614,6 +19514,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17751,6 +19655,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17764,6 +19681,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -17901,6 +19822,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -17914,6 +19848,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18074,6 +20012,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18087,6 +20038,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18224,6 +20179,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18237,6 +20205,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18374,6 +20346,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18387,6 +20372,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18547,6 +20536,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18560,6 +20562,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18697,6 +20703,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18710,6 +20729,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -18847,6 +20870,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -18860,6 +20896,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19019,6 +21059,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19032,6 +21085,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19169,6 +21226,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19182,6 +21252,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19319,6 +21393,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19332,6 +21419,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19491,6 +21582,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19504,6 +21608,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19641,6 +21749,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19654,6 +21775,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19791,6 +21916,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19804,6 +21942,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -19964,6 +22106,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -19977,6 +22132,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20114,6 +22273,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20127,6 +22299,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20264,6 +22440,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20277,6 +22466,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20441,6 +22634,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20454,6 +22660,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20591,6 +22801,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20604,6 +22827,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20741,6 +22968,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20754,6 +22994,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -20914,6 +23158,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -20927,6 +23184,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21064,6 +23325,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21077,6 +23351,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21214,6 +23492,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21227,6 +23518,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21393,6 +23688,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21406,6 +23714,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21543,6 +23855,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21556,6 +23881,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21693,6 +24022,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21706,6 +24048,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -21866,6 +24212,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -21879,6 +24238,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22016,6 +24379,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22029,6 +24405,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22166,6 +24546,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22179,6 +24572,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22339,6 +24736,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22352,6 +24762,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22489,6 +24903,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22502,6 +24929,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22639,6 +25070,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22652,6 +25096,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22812,6 +25260,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22825,6 +25286,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -22962,6 +25427,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -22975,6 +25453,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23112,6 +25594,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23125,6 +25620,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23289,6 +25788,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23302,6 +25814,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23439,6 +25955,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23452,6 +25981,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23589,6 +26122,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23602,6 +26148,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23768,6 +26318,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23781,6 +26344,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -23918,6 +26485,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -23931,6 +26511,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -24068,6 +26652,19 @@
           "brightness": 1.0,
           "saturation": 0.15
         },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
         "just_relax": {
           "speed": 0.6,
           "shape_offset": 0.728,
@@ -24081,6 +26678,10 @@
           "blue": 0.1,
           "saturation": 1.0,
           "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
         },
         "line_gradient": {
           "speed": 0.03,
@@ -24196,6 +26797,530 @@
         0.0
       ],
       "shader_mod_amounts_right": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "name": "Butterflies",
+      "shader_left": "LightPatternGenerator",
+      "shader_right": "BwGradient",
+      "colourise": "SolidHsvColour",
+      "left_right_mix": 0.23557943,
+      "blend_mode": "Multiply",
+      "shader_params_left": {
+        "acid_gradient": {
+          "speed": 0.5125,
+          "zoom": 0.0,
+          "offset": 0.75
+        },
+        "blinky_circles": {
+          "speed": 0.5125,
+          "zoom": 0.05,
+          "offset": 0.25
+        },
+        "bw_gradient": {
+          "speed": 0.5125,
+          "dc": 0.05,
+          "amp": 0.5,
+          "freq": 0.5,
+          "mirror": false
+        },
+        "colour_grid": {
+          "speed": 0.5,
+          "zoom_amount": 0.1,
+          "colour_amount": 0.5
+        },
+        "escher_tilings": {
+          "speed": 0.2,
+          "scale": 0.2,
+          "shape_iter": 0.2
+        },
+        "gilmore_acid": {
+          "speed": 0.025,
+          "displace": 0.01,
+          "colour_offset": 0.85,
+          "grid_size": 0.345,
+          "wave": 0.088,
+          "zoom_amount": 0.0,
+          "rotation_amount": 0.0,
+          "brightness": 1.0,
+          "saturation": 0.15
+        },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
+        "just_relax": {
+          "speed": 0.6,
+          "shape_offset": 0.728,
+          "iter": 1.0
+        },
+        "life_led_wall": {
+          "speed": 0.25,
+          "size": 0.73,
+          "red": 0.5,
+          "green": 0.2,
+          "blue": 0.1,
+          "saturation": 1.0,
+          "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.23433815,
+          "offset": 10.0
+        },
+        "line_gradient": {
+          "speed": 0.03,
+          "num_stripes": 1.0,
+          "stripe_width": 0.9,
+          "angle": 0.5,
+          "smooth_width": 0.155
+        },
+        "metafall": {
+          "speed": 0.47,
+          "scale": 0.0,
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "particle_zoom": {
+          "speed": 0.01,
+          "density": 0.01,
+          "shape": 0.35,
+          "tau": 1.0
+        },
+        "radial_lines": {
+          "speed": 0.05,
+          "zoom_amount": 0.8
+        },
+        "satis_spiraling": {
+          "speed": 0.5,
+          "loops": 0.8,
+          "mirror": true,
+          "rotate": true,
+          "colour_offset": 0.0
+        },
+        "spiral_intersect": {
+          "speed": 0.02,
+          "g1": 0.4,
+          "g2": 0.6,
+          "rot1": 1.0,
+          "rot2": 0.5,
+          "colours": 1.0
+        },
+        "square_tunnel": {
+          "speed": 0.6,
+          "rotation_speed": 0.025,
+          "rotation_offset": 0.0,
+          "zoom": 0.8
+        },
+        "the_pulse": {
+          "speed": 0.08,
+          "scale": 0.1,
+          "colour_iter": 0.25,
+          "thickness": 0.0
+        },
+        "tunnel_projection": {
+          "speed": 0.5,
+          "res": 0.5,
+          "y_offset": 0.5
+        },
+        "vert_colour_gradient": {
+          "speed": 0.5,
+          "scale": 0.83,
+          "colour_iter": 0.015,
+          "line_amp": 0.0,
+          "diag_amp": 0.0,
+          "boarder_amp": 0.65
+        },
+        "solid_hsv_colour": {
+          "hue": 1.0,
+          "saturation": 0.0,
+          "value": 1.0
+        },
+        "solid_rgb_colour": {
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "colour_palettes": {
+          "speed": 0.1,
+          "interval": 0.05,
+          "selected": 0
+        },
+        "mitch_wash": {
+          "speed": 1.0,
+          "pulse_speed": 1.0
+        },
+        "shape_envelopes": {
+          "speed": 1.0,
+          "pulse_speed": 1.0,
+          "line_thickness": 0.0,
+          "shape_thickness": 0.0
+        },
+        "row_test": {
+          "row": 0.0
+        },
+        "bar_test": {
+          "row": 0.0,
+          "bar": 0.0
+        }
+      },
+      "shader_params_colourise": {
+        "acid_gradient": {
+          "speed": 0.5125,
+          "zoom": 0.0,
+          "offset": 0.75
+        },
+        "blinky_circles": {
+          "speed": 0.5125,
+          "zoom": 0.05,
+          "offset": 0.25
+        },
+        "bw_gradient": {
+          "speed": 0.5125,
+          "dc": 0.05,
+          "amp": 0.5,
+          "freq": 0.5,
+          "mirror": false
+        },
+        "colour_grid": {
+          "speed": 0.5,
+          "zoom_amount": 0.1,
+          "colour_amount": 0.5
+        },
+        "escher_tilings": {
+          "speed": 0.2,
+          "scale": 0.2,
+          "shape_iter": 0.2
+        },
+        "gilmore_acid": {
+          "speed": 0.025,
+          "displace": 0.01,
+          "colour_offset": 0.85,
+          "grid_size": 0.345,
+          "wave": 0.088,
+          "zoom_amount": 0.0,
+          "rotation_amount": 0.0,
+          "brightness": 1.0,
+          "saturation": 0.15
+        },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
+        "just_relax": {
+          "speed": 0.6,
+          "shape_offset": 0.728,
+          "iter": 1.0
+        },
+        "life_led_wall": {
+          "speed": 0.25,
+          "size": 0.73,
+          "red": 0.5,
+          "green": 0.2,
+          "blue": 0.1,
+          "saturation": 1.0,
+          "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
+        },
+        "line_gradient": {
+          "speed": 0.03,
+          "num_stripes": 1.0,
+          "stripe_width": 0.9,
+          "angle": 0.5,
+          "smooth_width": 0.155
+        },
+        "metafall": {
+          "speed": 0.47,
+          "scale": 0.0,
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "particle_zoom": {
+          "speed": 0.01,
+          "density": 0.01,
+          "shape": 0.35,
+          "tau": 1.0
+        },
+        "radial_lines": {
+          "speed": 0.05,
+          "zoom_amount": 0.8
+        },
+        "satis_spiraling": {
+          "speed": 0.5,
+          "loops": 0.8,
+          "mirror": true,
+          "rotate": true,
+          "colour_offset": 0.0
+        },
+        "spiral_intersect": {
+          "speed": 0.02,
+          "g1": 0.4,
+          "g2": 0.6,
+          "rot1": 1.0,
+          "rot2": 0.5,
+          "colours": 1.0
+        },
+        "square_tunnel": {
+          "speed": 0.6,
+          "rotation_speed": 0.025,
+          "rotation_offset": 0.0,
+          "zoom": 0.8
+        },
+        "the_pulse": {
+          "speed": 0.08,
+          "scale": 0.1,
+          "colour_iter": 0.25,
+          "thickness": 0.0
+        },
+        "tunnel_projection": {
+          "speed": 0.5,
+          "res": 0.5,
+          "y_offset": 0.5
+        },
+        "vert_colour_gradient": {
+          "speed": 0.5,
+          "scale": 0.83,
+          "colour_iter": 0.015,
+          "line_amp": 0.0,
+          "diag_amp": 0.0,
+          "boarder_amp": 0.65
+        },
+        "solid_hsv_colour": {
+          "hue": 0.0,
+          "saturation": 0.0,
+          "value": 0.4782024
+        },
+        "solid_rgb_colour": {
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "colour_palettes": {
+          "speed": 0.1,
+          "interval": 0.05,
+          "selected": 0
+        },
+        "mitch_wash": {
+          "speed": 1.0,
+          "pulse_speed": 1.0
+        },
+        "shape_envelopes": {
+          "speed": 1.0,
+          "pulse_speed": 1.0,
+          "line_thickness": 0.0,
+          "shape_thickness": 0.0
+        },
+        "row_test": {
+          "row": 0.0
+        },
+        "bar_test": {
+          "row": 0.0,
+          "bar": 0.0
+        }
+      },
+      "shader_params_right": {
+        "acid_gradient": {
+          "speed": 0.5125,
+          "zoom": 0.0,
+          "offset": 0.75
+        },
+        "blinky_circles": {
+          "speed": 0.5125,
+          "zoom": 0.05,
+          "offset": 0.25
+        },
+        "bw_gradient": {
+          "speed": 0.039375737,
+          "dc": 0.0,
+          "amp": 0.33002284,
+          "freq": 0.75138193,
+          "mirror": false
+        },
+        "colour_grid": {
+          "speed": 0.5,
+          "zoom_amount": 0.1,
+          "colour_amount": 0.5
+        },
+        "escher_tilings": {
+          "speed": 0.2,
+          "scale": 0.2,
+          "shape_iter": 0.2
+        },
+        "gilmore_acid": {
+          "speed": 0.025,
+          "displace": 0.01,
+          "colour_offset": 0.85,
+          "grid_size": 0.345,
+          "wave": 0.088,
+          "zoom_amount": 0.0,
+          "rotation_amount": 0.0,
+          "brightness": 1.0,
+          "saturation": 0.15
+        },
+        "gradient_bars": {
+          "easing_type": 0,
+          "gradient_pow": 0.2,
+          "balance": 0.15,
+          "speed": 0.1,
+          "invert_speed": 0.2,
+          "offset": 4.0,
+          "use_odd_dirs": false,
+          "phase_iter": 2.0,
+          "num_columns": 15.0,
+          "x_iter": 2.0,
+          "use_columns": false
+        },
+        "just_relax": {
+          "speed": 0.6,
+          "shape_offset": 0.728,
+          "iter": 1.0
+        },
+        "life_led_wall": {
+          "speed": 0.25,
+          "size": 0.73,
+          "red": 0.5,
+          "green": 0.2,
+          "blue": 0.1,
+          "saturation": 1.0,
+          "colour_offset": 0.01
+        },
+        "light_pattern_generator": {
+          "zoom": 0.5,
+          "offset": 0.2
+        },
+        "line_gradient": {
+          "speed": 0.03,
+          "num_stripes": 1.0,
+          "stripe_width": 0.9,
+          "angle": 0.5,
+          "smooth_width": 0.155
+        },
+        "metafall": {
+          "speed": 0.47,
+          "scale": 0.0,
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "particle_zoom": {
+          "speed": 0.01,
+          "density": 0.01,
+          "shape": 0.35,
+          "tau": 1.0
+        },
+        "radial_lines": {
+          "speed": 0.05,
+          "zoom_amount": 0.8
+        },
+        "satis_spiraling": {
+          "speed": 0.5,
+          "loops": 0.8,
+          "mirror": true,
+          "rotate": true,
+          "colour_offset": 0.0
+        },
+        "spiral_intersect": {
+          "speed": 0.02,
+          "g1": 0.4,
+          "g2": 0.6,
+          "rot1": 1.0,
+          "rot2": 0.5,
+          "colours": 1.0
+        },
+        "square_tunnel": {
+          "speed": 0.6,
+          "rotation_speed": 0.025,
+          "rotation_offset": 0.0,
+          "zoom": 0.8
+        },
+        "the_pulse": {
+          "speed": 0.08,
+          "scale": 0.1,
+          "colour_iter": 0.25,
+          "thickness": 0.0
+        },
+        "tunnel_projection": {
+          "speed": 0.5,
+          "res": 0.5,
+          "y_offset": 0.5
+        },
+        "vert_colour_gradient": {
+          "speed": 0.5,
+          "scale": 0.83,
+          "colour_iter": 0.015,
+          "line_amp": 0.0,
+          "diag_amp": 0.0,
+          "boarder_amp": 0.65
+        },
+        "solid_hsv_colour": {
+          "hue": 1.0,
+          "saturation": 0.0,
+          "value": 1.0
+        },
+        "solid_rgb_colour": {
+          "red": 1.0,
+          "green": 1.0,
+          "blue": 1.0
+        },
+        "colour_palettes": {
+          "speed": 0.1,
+          "interval": 0.05,
+          "selected": 0
+        },
+        "mitch_wash": {
+          "speed": 1.0,
+          "pulse_speed": 1.0
+        },
+        "shape_envelopes": {
+          "speed": 1.0,
+          "pulse_speed": 1.0,
+          "line_thickness": 0.0,
+          "shape_thickness": 0.0
+        },
+        "row_test": {
+          "row": 0.0
+        },
+        "bar_test": {
+          "row": 0.0,
+          "bar": 0.0
+        }
+      },
+      "shader_mod_amounts_left": [
+        0.0,
+        0.0
+      ],
+      "shader_mod_amounts_colourise": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "shader_mod_amounts_right": [
+        0.0,
         0.0,
         0.0,
         0.0

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -693,6 +693,33 @@ impl Params for shader_shared::LifeLedWall {
     }
 }
 
+impl Params for shader_shared::LightPatternGenerator {
+    fn param_count(&self) -> usize {
+        2
+    }
+    fn param_mut(&mut self, ix: usize) -> ParamMut<'_> {
+        match ix {
+            0 => ParamMut {
+                name: "Zoom",
+                kind: ParamKindMut::F32Range {
+                    value: &mut self.zoom,
+                    min: 0.0,
+                    max: 1.0,
+                },
+            },
+            1 => ParamMut {
+                name: "Offset",
+                kind: ParamKindMut::F32Range {
+                    value: &mut self.offset,
+                    min: 0.0,
+                    max: 10.0,
+                },
+            },
+            _ => panic!("no parameter for index {}: check `param_count` impl", ix),
+        }
+    }
+}
+
 impl Params for shader_shared::LineGradient {
     fn param_count(&self) -> usize {
         5
@@ -3172,6 +3199,7 @@ pub fn shader_params(shader: Shader, params: &mut ShaderParams) -> &mut dyn Para
         Shader::GradientBars => &mut params.gradient_bars,
         Shader::JustRelax => &mut params.just_relax,
         Shader::LifeLedWall => &mut params.life_led_wall,
+        Shader::LightPatternGenerator => &mut params.light_pattern_generator,
         Shader::LineGradient => &mut params.line_gradient,
         Shader::Metafall => &mut params.metafall,
         Shader::ParticleZoom => &mut params.particle_zoom,

--- a/shader/src/led_shaders/light_pattern_generator.rs
+++ b/shader/src/led_shaders/light_pattern_generator.rs
@@ -1,0 +1,52 @@
+use nannou_core::prelude::*;
+use shader_shared::{Light, Uniforms, Vertex};
+
+use crate::helpers::TWO_PI;
+
+fn glsl_fract(value: f32) -> f32 {
+    value - value.floor()
+}
+
+fn glsl_fract_vec2(v: Vec2) -> Vec2 {
+    vec2(glsl_fract(v.x), glsl_fract(v.y))
+}
+
+fn palette(t: f32, a: Vec3, b: Vec3, c: Vec3, d: Vec3) -> Vec3 {
+    a + b * vec3(
+        (TWO_PI * (c.x * t + d.x)).cos(),
+        (TWO_PI * (c.y * t + d.y)).cos(),
+        (TWO_PI * (c.z * t + d.z)).cos(),
+    )
+}
+
+pub fn shader(v: Vertex, uniforms: &Uniforms) -> LinSrgb {
+    let params = uniforms.params.light_pattern_generator;
+
+    let Light::Led {
+        normalised_coords, ..
+    } = v.light;
+
+    let mut uv = normalised_coords;
+    let t = uniforms.time * 0.125;
+    let d = 0.3 * params.offset;
+
+    let zoom = 8.0 + params.zoom * 64.0;
+    let mut g = uv * zoom;
+    uv = d * (vec2(g.x.floor(), g.y.floor()) + vec2(0.5, 0.5)) / zoom;
+    g = glsl_fract_vec2(g) * 2.0 - vec2(1.0, 1.0);
+
+    let f = uv.dot(uv) - t;
+    let colour = palette(
+        f * 0.5 + t,
+        vec3(0.5, 0.5, 0.5),
+        vec3(0.5, 0.5, 0.5),
+        vec3(1.0, 1.0, 1.0),
+        vec3(0.0, 0.10, 0.20),
+    );
+
+    let denom = ((glsl_fract(f) - 0.5) * 8.0).abs().max(0.0001);
+    let intensity = (1.0 - g.y * g.y) * 0.2 / denom;
+    let colour = colour * intensity;
+
+    lin_srgb(colour.x, colour.y, colour.z)
+}

--- a/shader/src/led_shaders/mod.rs
+++ b/shader/src/led_shaders/mod.rs
@@ -8,6 +8,7 @@ pub mod gilmore_acid;
 pub mod gradient_bars;
 pub mod just_relax;
 pub mod life_led_wall;
+pub mod light_pattern_generator;
 pub mod line_gradient;
 pub mod metafall;
 pub mod particle_zoom;

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -73,6 +73,7 @@ fn get_shader(shader: Shader) -> fn(Vertex, &Uniforms) -> LinSrgb {
         Shader::GradientBars => led_shaders::gradient_bars::shader,
         Shader::JustRelax => led_shaders::just_relax::shader,
         Shader::LifeLedWall => led_shaders::life_led_wall::shader,
+        Shader::LightPatternGenerator => led_shaders::light_pattern_generator::shader,
         Shader::LineGradient => led_shaders::line_gradient::shader,
         Shader::Metafall => led_shaders::metafall::shader,
         Shader::ParticleZoom => led_shaders::particle_zoom::shader,

--- a/shader_shared/src/lib.rs
+++ b/shader_shared/src/lib.rs
@@ -161,6 +161,8 @@ pub struct ShaderParams {
     #[serde(default)]
     pub life_led_wall: LifeLedWall,
     #[serde(default)]
+    pub light_pattern_generator: LightPatternGenerator,
+    #[serde(default)]
     pub line_gradient: LineGradient,
     #[serde(default)]
     pub metafall: Metafall,
@@ -223,6 +225,7 @@ pub enum Shader {
     GradientBars,
     JustRelax,
     LifeLedWall,
+    LightPatternGenerator,
     LineGradient,
     Metafall,
     ParticleZoom,
@@ -401,6 +404,14 @@ pub struct LifeLedWall {
     pub saturation: f32,
     #[devault("0.01")]
     pub colour_offset: f32,
+}
+
+#[derive(Copy, Clone, Debug, Devault, PartialEq, Serialize, Deserialize)]
+pub struct LightPatternGenerator {
+    #[devault("0.5")]
+    pub zoom: f32,
+    #[devault("0.2")]
+    pub offset: f32,
 }
 
 #[derive(Copy, Clone, Debug, Devault, PartialEq, Serialize, Deserialize)]
@@ -620,6 +631,7 @@ pub const ALL_SHADERS: &[Shader] = &[
     Shader::GradientBars,
     Shader::JustRelax,
     Shader::LifeLedWall,
+    Shader::LightPatternGenerator,
     Shader::LineGradient,
     Shader::Metafall,
     Shader::ParticleZoom,
@@ -699,6 +711,7 @@ impl Shader {
             Shader::GradientBars => "GradientBars",
             Shader::JustRelax => "JustRelax",
             Shader::LifeLedWall => "LifeLedWall",
+            Shader::LightPatternGenerator => "LightPatternGenerator",
             Shader::LineGradient => "LineGradient",
             Shader::Metafall => "Metafall",
             Shader::ParticleZoom => "ParticleZoom",
@@ -730,20 +743,21 @@ impl Shader {
             Shader::GradientBars => 9,
             Shader::JustRelax => 10,
             Shader::LifeLedWall => 11,
-            Shader::LineGradient => 12,
-            Shader::Metafall => 13,
-            Shader::ParticleZoom => 14,
-            Shader::RadialLines => 15,
-            Shader::SatisSpiraling => 16,
-            Shader::SpiralIntersect => 17,
-            Shader::SquareTunnel => 18,
-            Shader::ThePulse => 19,
-            Shader::TunnelProjection => 20,
-            Shader::VertColourGradient => 21,
-            Shader::MitchWash => 22,
-            Shader::ShapeEnvelopes => 23,
-            Shader::RowTest => 24,
-            Shader::BarTest => 25,
+            Shader::LightPatternGenerator => 12,
+            Shader::LineGradient => 13,
+            Shader::Metafall => 14,
+            Shader::ParticleZoom => 15,
+            Shader::RadialLines => 16,
+            Shader::SatisSpiraling => 17,
+            Shader::SpiralIntersect => 18,
+            Shader::SquareTunnel => 19,
+            Shader::ThePulse => 20,
+            Shader::TunnelProjection => 21,
+            Shader::VertColourGradient => 22,
+            Shader::MitchWash => 23,
+            Shader::ShapeEnvelopes => 24,
+            Shader::RowTest => 25,
+            Shader::BarTest => 26,
         }
     }
 
@@ -761,20 +775,21 @@ impl Shader {
             9 => Shader::GradientBars,
             10 => Shader::JustRelax,
             11 => Shader::LifeLedWall,
-            12 => Shader::LineGradient,
-            13 => Shader::Metafall,
-            14 => Shader::ParticleZoom,
-            15 => Shader::RadialLines,
-            16 => Shader::SatisSpiraling,
-            17 => Shader::SpiralIntersect,
-            18 => Shader::SquareTunnel,
-            19 => Shader::ThePulse,
-            20 => Shader::TunnelProjection,
-            21 => Shader::VertColourGradient,
-            22 => Shader::MitchWash,
-            23 => Shader::ShapeEnvelopes,
-            24 => Shader::RowTest,
-            25 => Shader::BarTest,
+            12 => Shader::LightPatternGenerator,
+            13 => Shader::LineGradient,
+            14 => Shader::Metafall,
+            15 => Shader::ParticleZoom,
+            16 => Shader::RadialLines,
+            17 => Shader::SatisSpiraling,
+            18 => Shader::SpiralIntersect,
+            19 => Shader::SquareTunnel,
+            20 => Shader::ThePulse,
+            21 => Shader::TunnelProjection,
+            22 => Shader::VertColourGradient,
+            23 => Shader::MitchWash,
+            24 => Shader::ShapeEnvelopes,
+            25 => Shader::RowTest,
+            26 => Shader::BarTest,
             _ => return None,
         };
         Some(shader)


### PR DESCRIPTION
## Summary
- port the light pattern generator shader into the LED shader system
- add shared shader params and GUI controls for the shader's zoom and offset inputs
- include the saved preset update in assets/presets.json

## Testing
- cargo fmt --all
- cargo check --workspace