### PR TITLE
Add global animation controls and MIDI mapping

### DIFF
--- a/cohen_gig/src/audio_widgets.rs
+++ b/cohen_gig/src/audio_widgets.rs
@@ -1,5 +1,6 @@
 use crate::audio_input::{AudioInput, MAX_INPUT_GAIN_DB};
 use crate::gui::{self, slider, COLUMN_ONE_SECTION_GAP, COLUMN_W, TEXT_COLOR};
+use crate::mod_slider::ModSlider;
 use crate::mod_slider::SmoothedSlider;
 use nannou_conrod::prelude::*;
 use std::collections::VecDeque;
@@ -14,6 +15,9 @@ pub fn set_widgets(
     smoothing_speed: &mut f32,
     master_speed: &mut f32,
     smoothed_master_speed: f32,
+    phase_offset: &mut f32,
+    phase_offset_mod_amount: &mut f32,
+    smoothed_phase_offset: f32,
     anchor_id: widget::Id,
 ) {
     widget::Text::new("AUDIO INPUT")
@@ -163,6 +167,7 @@ pub fn set_widgets(
     let label = format!("Smoothing Speed: {:.4}", *smoothing_speed);
     if let Some(v) = slider(*smoothing_speed, 0.0008, 0.08)
         .down(5.0)
+        .w_h(COLUMN_W, 30.0)
         .label(&label)
         .set(ids.smoothing_speed_slider, ui)
     {
@@ -172,10 +177,29 @@ pub fn set_widgets(
     let label = format!("Master Speed: {:.3}", *master_speed);
     if let Some(v) = SmoothedSlider::new(*master_speed, smoothed_master_speed, 0.0, 1.0)
         .down(5.0)
+        .w_h(COLUMN_W, 30.0)
         .label(&label)
         .set(ids.master_speed_slider, ui)
     {
         *master_speed = v;
+    }
+
+    let label = format!("Phase Offset: {:+.3}", *phase_offset);
+    if let Some((v, m)) = ModSlider::new(
+        *phase_offset,
+        smoothed_phase_offset,
+        *phase_offset_mod_amount,
+        audio.envelope,
+        gui::GLOBAL_PHASE_OFFSET_MIN,
+        gui::GLOBAL_PHASE_OFFSET_MAX,
+    )
+    .down(5.0)
+    .label(&label)
+    .w_h(COLUMN_W, 30.0)
+    .set(ids.phase_offset_slider, ui)
+    {
+        *phase_offset = v;
+        *phase_offset_mod_amount = m;
     }
 }
 

--- a/cohen_gig/src/audio_widgets.rs
+++ b/cohen_gig/src/audio_widgets.rs
@@ -1,5 +1,6 @@
 use crate::audio_input::{AudioInput, MAX_INPUT_GAIN_DB};
 use crate::gui::{self, slider, COLUMN_ONE_SECTION_GAP, COLUMN_W, TEXT_COLOR};
+use crate::mod_slider::SmoothedSlider;
 use nannou_conrod::prelude::*;
 use std::collections::VecDeque;
 
@@ -11,6 +12,8 @@ pub fn set_widgets(
     audio: &mut AudioInput,
     preferred_device_name: &mut String,
     smoothing_speed: &mut f32,
+    master_speed: &mut f32,
+    smoothed_master_speed: f32,
     anchor_id: widget::Id,
 ) {
     widget::Text::new("AUDIO INPUT")
@@ -164,6 +167,15 @@ pub fn set_widgets(
         .set(ids.smoothing_speed_slider, ui)
     {
         *smoothing_speed = v;
+    }
+
+    let label = format!("Master Speed: {:.3}", *master_speed);
+    if let Some(v) = SmoothedSlider::new(*master_speed, smoothed_master_speed, 0.0, 1.0)
+        .down(5.0)
+        .label(&label)
+        .set(ids.master_speed_slider, ui)
+    {
+        *master_speed = v;
     }
 }
 

--- a/cohen_gig/src/audio_widgets.rs
+++ b/cohen_gig/src/audio_widgets.rs
@@ -10,6 +10,7 @@ pub fn set_widgets(
     ids: &gui::Ids,
     audio: &mut AudioInput,
     preferred_device_name: &mut String,
+    smoothing_speed: &mut f32,
     anchor_id: widget::Id,
 ) {
     widget::Text::new("AUDIO INPUT")
@@ -148,6 +149,22 @@ pub fn set_widgets(
         ids.audio_envelope_scope,
         &audio.envelope_history,
     );
+
+    widget::Text::new("GLOBAL PARAMS")
+        .down_from(ids.audio_envelope_scope_bg, COLUMN_ONE_SECTION_GAP)
+        .align_left_of(ids.column_1_id)
+        .color(TEXT_COLOR)
+        .font_size(14)
+        .set(ids.global_params_text, ui);
+
+    let label = format!("Smoothing Speed: {:.4}", *smoothing_speed);
+    if let Some(v) = slider(*smoothing_speed, 0.0008, 0.08)
+        .down(5.0)
+        .label(&label)
+        .set(ids.smoothing_speed_slider, ui)
+    {
+        *smoothing_speed = v;
+    }
 }
 
 fn draw_waveform(

--- a/cohen_gig/src/conf.rs
+++ b/cohen_gig/src/conf.rs
@@ -49,6 +49,10 @@ pub struct GlobalConfig {
     pub preset_lerp_secs: f32,
     #[serde(default = "default::master_speed")]
     pub master_speed: f32,
+    #[serde(default = "default::phase_offset")]
+    pub phase_offset: f32,
+    #[serde(default = "default::phase_offset_mod_amount")]
+    pub phase_offset_mod_amount: f32,
     /// Order and current selection of the per-file shader presets.
     #[serde(default)]
     pub shader_preset_index: ShaderPresetIndex,
@@ -383,6 +387,8 @@ impl Default for GlobalConfig {
             madmapper_project_path: None,
             preset_lerp_secs: Default::default(),
             master_speed: default::master_speed(),
+            phase_offset: default::phase_offset(),
+            phase_offset_mod_amount: default::phase_offset_mod_amount(),
             shader_preset_index: Default::default(),
         }
     }
@@ -923,6 +929,14 @@ pub mod default {
 
     pub fn master_speed() -> f32 {
         1.0
+    }
+
+    pub fn phase_offset() -> f32 {
+        0.0
+    }
+
+    pub fn phase_offset_mod_amount() -> f32 {
+        0.0
     }
 
     pub mod led_layout {

--- a/cohen_gig/src/conf.rs
+++ b/cohen_gig/src/conf.rs
@@ -47,6 +47,8 @@ pub struct GlobalConfig {
     pub madmapper_project_path: Option<String>,
     #[serde(default)]
     pub preset_lerp_secs: f32,
+    #[serde(default = "default::master_speed")]
+    pub master_speed: f32,
     /// Order and current selection of the per-file shader presets.
     #[serde(default)]
     pub shader_preset_index: ShaderPresetIndex,
@@ -380,6 +382,7 @@ impl Default for GlobalConfig {
             led_layout: Default::default(),
             madmapper_project_path: None,
             preset_lerp_secs: Default::default(),
+            master_speed: default::master_speed(),
             shader_preset_index: Default::default(),
         }
     }
@@ -916,6 +919,10 @@ pub mod default {
 
     pub fn sacn_interface_ip() -> String {
         String::new()
+    }
+
+    pub fn master_speed() -> f32 {
+        1.0
     }
 
     pub mod led_layout {

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -22,6 +22,8 @@ pub const WINDOW_WIDTH: u32 =
 pub const WINDOW_HEIGHT: u32 = 1050 - (2.0 * PAD) as u32;
 pub const WIDGET_W: Scalar = COLUMN_W;
 pub const HALF_WIDGET_W: Scalar = WIDGET_W * 0.5 - PAD * 0.25;
+pub const GLOBAL_PHASE_OFFSET_MIN: f32 = -0.2;
+pub const GLOBAL_PHASE_OFFSET_MAX: f32 = 0.2;
 pub const BUTTON_COLOR: Color = Color::Rgba(0.11, 0.39, 0.4, 1.0); // teal
 pub const TEXT_COLOR: Color = Color::Rgba(1.0, 1.0, 1.0, 1.0);
 pub const PRESET_LIST_COLOR: Color = Color::Rgba(0.16, 0.32, 0.6, 1.0); // blue
@@ -131,6 +133,7 @@ widget_ids! {
         global_params_text,
         smoothing_speed_slider,
         master_speed_slider,
+        phase_offset_slider,
 
         sacn_output_title_text,
         sacn_output_status_text,
@@ -219,6 +222,7 @@ pub struct UpdateContext<'a> {
         &'a mut std::collections::HashMap<crate::midi::mapping::MidiTarget, crate::MidiTargetState>,
     pub smoothing_speed: &'a mut f32,
     pub smoothed_master_speed: f32,
+    pub smoothed_phase_offset: f32,
     pub smoothed_preset: &'a crate::conf::Preset,
     pub preview_left_image_id: Option<ui::image::Id>,
     pub preview_right_image_id: Option<ui::image::Id>,
@@ -1633,6 +1637,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
         midi_values,
         smoothing_speed,
         smoothed_master_speed,
+        smoothed_phase_offset,
         smoothed_preset,
         preview_left_image_id,
         preview_right_image_id,
@@ -1732,6 +1737,9 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 smoothing_speed,
                 &mut global_config.master_speed,
                 smoothed_master_speed,
+                &mut global_config.phase_offset,
+                &mut global_config.phase_offset_mod_amount,
+                smoothed_phase_offset,
                 audio_anchor,
             );
             set_presets_widgets(

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -128,6 +128,8 @@ widget_ids! {
         audio_release_slider,
         audio_envelope_scope_bg,
         audio_envelope_scope,
+        global_params_text,
+        smoothing_speed_slider,
 
         sacn_output_title_text,
         sacn_output_status_text,
@@ -214,6 +216,8 @@ pub struct UpdateContext<'a> {
     pub midi_learn: &'a mut crate::midi::learn::LearnState,
     pub midi_values:
         &'a mut std::collections::HashMap<crate::midi::mapping::MidiTarget, crate::MidiTargetState>,
+    pub smoothing_speed: &'a mut f32,
+    pub smoothed_preset: &'a crate::conf::Preset,
     pub preview_left_image_id: Option<ui::image::Id>,
     pub preview_right_image_id: Option<ui::image::Id>,
     pub preview_colourise_image_id: Option<ui::image::Id>,
@@ -264,6 +268,7 @@ struct ShaderWidgetState<'a> {
     dropdown_ix: &'a mut usize,
     button_ix: &'a mut usize,
     mod_amounts: &'a mut Vec<f32>,
+    smoothed_values: &'a [f32],
     /// Offset into mod_amounts for this slot (mod_slider_ix is global for widget IDs).
     mod_amounts_offset: usize,
     envelope: f32,
@@ -1624,6 +1629,8 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
         midi_mapping,
         midi_learn,
         midi_values,
+        smoothing_speed,
+        smoothed_preset,
         preview_left_image_id,
         preview_right_image_id,
         preview_colourise_image_id,
@@ -1719,6 +1726,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 ids,
                 audio_input,
                 &mut global_config.audio_input_device,
+                smoothing_speed,
                 audio_anchor,
             );
             set_presets_widgets(
@@ -1803,6 +1811,13 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
         shader_right_dropdown.is_open = false;
     }
 
+    let smoothed_left_values =
+        shader_param_f32_values(smoothed_preset.shader_left, smoothed_preset.shader_params_left);
+    let smoothed_colourise_values =
+        shader_param_f32_values(smoothed_preset.colourise, smoothed_preset.shader_params_colourise);
+    let smoothed_right_values =
+        shader_param_f32_values(smoothed_preset.shader_right, smoothed_preset.shader_params_right);
+
     let mut mod_slider_ix = 0;
     let mut int_slider_ix = 0;
     let mut dropdown_ix = 0;
@@ -1821,6 +1836,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 dropdown_ix: &mut dropdown_ix,
                 button_ix: &mut button_ix,
                 mod_amounts: &mut preset.shader_mod_amounts_left,
+                smoothed_values: &smoothed_left_values,
                 mod_amounts_offset: mod_start,
                 envelope: audio_input.envelope,
             },
@@ -1877,6 +1893,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 dropdown_ix: &mut dropdown_ix,
                 button_ix: &mut button_ix,
                 mod_amounts: &mut preset.shader_mod_amounts_colourise,
+                smoothed_values: &smoothed_colourise_values,
                 mod_amounts_offset: mod_start,
                 envelope: audio_input.envelope,
             },
@@ -1967,6 +1984,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 dropdown_ix: &mut dropdown_ix,
                 button_ix: &mut button_ix,
                 mod_amounts: &mut preset.shader_mod_amounts_right,
+                smoothed_values: &smoothed_right_values,
                 mod_amounts_offset: mod_start,
                 envelope: audio_input.envelope,
             },
@@ -3245,6 +3263,7 @@ fn set_shader_widgets(
         dropdown_ix,
         button_ix,
         mod_amounts,
+        smoothed_values,
         mod_amounts_offset,
         envelope,
     } = state;
@@ -3264,8 +3283,10 @@ fn set_shader_widgets(
                 }
                 let id = ids.shader_mod_sliders[*mod_slider_ix];
                 let mod_amt = mod_amounts[local_ix];
+                let smoothed_value = smoothed_values.get(local_ix).copied().unwrap_or(*value);
 
-                if let Some((v, m)) = ModSlider::new(*value, mod_amt, envelope, 0.0, max)
+                if let Some((v, m)) =
+                    ModSlider::new(*value, smoothed_value, mod_amt, envelope, 0.0, max)
                     .label(name)
                     .w_h(COLUMN_W, 30.0)
                     .down(10.0)
@@ -3289,8 +3310,10 @@ fn set_shader_widgets(
                 }
                 let id = ids.shader_mod_sliders[*mod_slider_ix];
                 let mod_amt = mod_amounts[local_ix];
+                let smoothed_value = smoothed_values.get(local_ix).copied().unwrap_or(*value);
 
-                if let Some((v, m)) = ModSlider::new(*value, mod_amt, envelope, min, max)
+                if let Some((v, m)) =
+                    ModSlider::new(*value, smoothed_value, mod_amt, envelope, min, max)
                     .label(name)
                     .w_h(COLUMN_W, 30.0)
                     .down(10.0)
@@ -3491,6 +3514,21 @@ pub fn shader_modulation_slot_count(shader: Shader, params: &mut ShaderParams) -
         }
     }
     count
+}
+
+pub fn shader_param_f32_values(shader: Shader, mut params: ShaderParams) -> Vec<f32> {
+    let p: &mut dyn Params = shader_params(shader, &mut params);
+    let mut values = Vec::new();
+    for ix in 0..p.param_count() {
+        let ParamMut { kind, .. } = p.param_mut(ix);
+        match kind {
+            ParamKindMut::F32 { value, .. } | ParamKindMut::F32Range { value, .. } => {
+                values.push(*value);
+            }
+            ParamKindMut::Bool(_) | ParamKindMut::Select { .. } | ParamKindMut::Usize { .. } => {}
+        }
+    }
+    values
 }
 
 pub fn shader_params(shader: Shader, params: &mut ShaderParams) -> &mut dyn Params {

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -130,6 +130,7 @@ widget_ids! {
         audio_envelope_scope,
         global_params_text,
         smoothing_speed_slider,
+        master_speed_slider,
 
         sacn_output_title_text,
         sacn_output_status_text,
@@ -217,6 +218,7 @@ pub struct UpdateContext<'a> {
     pub midi_values:
         &'a mut std::collections::HashMap<crate::midi::mapping::MidiTarget, crate::MidiTargetState>,
     pub smoothing_speed: &'a mut f32,
+    pub smoothed_master_speed: f32,
     pub smoothed_preset: &'a crate::conf::Preset,
     pub preview_left_image_id: Option<ui::image::Id>,
     pub preview_right_image_id: Option<ui::image::Id>,
@@ -1630,6 +1632,7 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
         midi_learn,
         midi_values,
         smoothing_speed,
+        smoothed_master_speed,
         smoothed_preset,
         preview_left_image_id,
         preview_right_image_id,
@@ -1727,6 +1730,8 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
                 audio_input,
                 &mut global_config.audio_input_device,
                 smoothing_speed,
+                &mut global_config.master_speed,
+                smoothed_master_speed,
                 audio_anchor,
             );
             set_presets_widgets(
@@ -1811,12 +1816,18 @@ pub fn update(ui: &mut UiCell, ctx: UpdateContext<'_>) {
         shader_right_dropdown.is_open = false;
     }
 
-    let smoothed_left_values =
-        shader_param_f32_values(smoothed_preset.shader_left, smoothed_preset.shader_params_left);
-    let smoothed_colourise_values =
-        shader_param_f32_values(smoothed_preset.colourise, smoothed_preset.shader_params_colourise);
-    let smoothed_right_values =
-        shader_param_f32_values(smoothed_preset.shader_right, smoothed_preset.shader_params_right);
+    let smoothed_left_values = shader_param_f32_values(
+        smoothed_preset.shader_left,
+        smoothed_preset.shader_params_left,
+    );
+    let smoothed_colourise_values = shader_param_f32_values(
+        smoothed_preset.colourise,
+        smoothed_preset.shader_params_colourise,
+    );
+    let smoothed_right_values = shader_param_f32_values(
+        smoothed_preset.shader_right,
+        smoothed_preset.shader_params_right,
+    );
 
     let mut mod_slider_ix = 0;
     let mut int_slider_ix = 0;
@@ -3287,10 +3298,10 @@ fn set_shader_widgets(
 
                 if let Some((v, m)) =
                     ModSlider::new(*value, smoothed_value, mod_amt, envelope, 0.0, max)
-                    .label(name)
-                    .w_h(COLUMN_W, 30.0)
-                    .down(10.0)
-                    .set(id, ui)
+                        .label(name)
+                        .w_h(COLUMN_W, 30.0)
+                        .down(10.0)
+                        .set(id, ui)
                 {
                     *value = v;
                     mod_amounts[local_ix] = m;
@@ -3314,10 +3325,10 @@ fn set_shader_widgets(
 
                 if let Some((v, m)) =
                     ModSlider::new(*value, smoothed_value, mod_amt, envelope, min, max)
-                    .label(name)
-                    .w_h(COLUMN_W, 30.0)
-                    .down(10.0)
-                    .set(id, ui)
+                        .label(name)
+                        .w_h(COLUMN_W, 30.0)
+                        .down(10.0)
+                        .set(id, ui)
                 {
                     *value = v;
                     mod_amounts[local_ix] = m;

--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -77,6 +77,8 @@ struct Model {
     presets: conf::Presets,
     smoothed_preset: conf::Preset,
     smoothing_speed: f32,
+    smoothed_master_speed: f32,
+    master_phase: f32,
     colour_channels: [f32; 3],
     buttons: HashMap<shader_shared::Button, ButtonState>,
     led_colors: Vec<LinSrgb>,
@@ -199,6 +201,7 @@ struct LedWorkerConfig {
     led_start_universe: u16,
     fade_to_black_led: f32,
     preset_lerp_secs: f32,
+    master_speed: f32,
     led_layout: conf::LedLayout,
     preset: conf::Preset,
     /// Resolved layout from MadMapper, if active.
@@ -554,12 +557,14 @@ fn model(app: &App) -> Model {
     let audio_input = audio_input::AudioInput::new(128, global_config.audio_input_device.clone());
     let colour_channels = [1.0, 0.0, 1.0]; // R/H, G/S, B/V defaults
     let smoothed_preset = presets.selected().clone();
+    let smoothed_master_speed = global_config.master_speed;
 
     let resolved_layout = mad_project.as_ref().map(layout::resolve_from_mad_project);
 
     let last_preset_change = None;
     let led_worker = LedWorker::new(build_led_worker_input_state(
         0.0,
+        smoothed_master_speed,
         &global_config,
         &smoothed_preset,
         &audio_input,
@@ -583,6 +588,8 @@ fn model(app: &App) -> Model {
         presets,
         smoothed_preset,
         smoothing_speed: 0.05,
+        smoothed_master_speed,
+        master_phase: 0.0,
         colour_channels,
         buttons: Default::default(),
         led_colors,
@@ -927,6 +934,7 @@ pub fn rebuild_led_shader_inputs(led_layout: &conf::LedLayout) -> Vec<CachedLedS
 
 fn build_led_worker_input_state(
     app_time: f32,
+    master_speed: f32,
     global_config: &GlobalConfig,
     preset: &conf::Preset,
     audio_input: &audio_input::AudioInput,
@@ -945,6 +953,7 @@ fn build_led_worker_input_state(
             led_start_universe: global_config.led_start_universe,
             fade_to_black_led: global_config.fade_to_black.led,
             preset_lerp_secs: global_config.preset_lerp_secs,
+            master_speed,
             led_layout: global_config.led_layout.clone(),
             preset: preset.clone(),
             resolved_layout,
@@ -1075,10 +1084,11 @@ fn apply_midi_values(model: &mut Model) {
     }
 }
 
-fn queue_led_worker_update(app: &App, model: &mut Model) {
+fn queue_led_worker_update(_app: &App, model: &mut Model) {
     if let Ok(mut shared_input) = model.led_worker.shared_input.lock() {
         shared_input.latest_state = build_led_worker_input_state(
-            app.time,
+            model.master_phase,
+            model.smoothed_master_speed,
             &model.global_config,
             &model.smoothed_preset,
             &model.audio_input,
@@ -1178,6 +1188,12 @@ fn update_smoothed_preset(model: &mut Model) {
         target.shader_params_right,
         model.smoothing_speed,
     );
+}
+
+fn update_smoothed_master_speed(model: &mut Model) {
+    let target = model.global_config.master_speed;
+    model.smoothed_master_speed = model.smoothed_master_speed * (1.0 - model.smoothing_speed)
+        + target * model.smoothing_speed;
 }
 
 fn apply_led_worker_output(model: &mut Model) {
@@ -1694,7 +1710,8 @@ fn preset_uniforms(state: &LedWorkerInputState, preset: &conf::Preset) -> Unifor
             (button, state)
         })
         .collect();
-    let time = state.app_time + state.snapshot_at.elapsed().as_secs_f32();
+    let time =
+        state.app_time + state.snapshot_at.elapsed().as_secs_f32() * state.config.master_speed;
     Uniforms {
         time,
         resolution: layout::shader_resolution(led_layout),
@@ -1905,6 +1922,7 @@ fn update(app: &App, model: &mut Model, update: Update) {
             midi_learn: &mut model.midi_learn,
             midi_values: &mut model.midi_values,
             smoothing_speed: &mut model.smoothing_speed,
+            smoothed_master_speed: model.smoothed_master_speed,
             smoothed_preset: &model.smoothed_preset,
             preview_left_image_id: model.preview_images.as_ref().map(|pi| pi.left_id),
             preview_right_image_id: model.preview_images.as_ref().map(|pi| pi.right_id),
@@ -1990,7 +2008,9 @@ fn update(app: &App, model: &mut Model, update: Update) {
     // Apply smoothed MIDI values to their destinations.
     apply_midi_values(model);
 
+    update_smoothed_master_speed(model);
     update_smoothed_preset(model);
+    model.master_phase += update.since_last.as_secs_f32() * model.smoothed_master_speed;
 
     queue_led_worker_update(app, model);
 }

--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -75,6 +75,7 @@ struct Model {
     shader_rx: ShaderReceiver,
     global_config: GlobalConfig,
     presets: conf::Presets,
+    smoothed_preset: conf::Preset,
     smoothing_speed: f32,
     colour_channels: [f32; 3],
     buttons: HashMap<shader_shared::Button, ButtonState>,
@@ -552,6 +553,7 @@ fn model(app: &App) -> Model {
 
     let audio_input = audio_input::AudioInput::new(128, global_config.audio_input_device.clone());
     let colour_channels = [1.0, 0.0, 1.0]; // R/H, G/S, B/V defaults
+    let smoothed_preset = presets.selected().clone();
 
     let resolved_layout = mad_project.as_ref().map(layout::resolve_from_mad_project);
 
@@ -559,7 +561,7 @@ fn model(app: &App) -> Model {
     let led_worker = LedWorker::new(build_led_worker_input_state(
         0.0,
         &global_config,
-        &presets,
+        &smoothed_preset,
         &audio_input,
         colour_channels,
         gui::LeftPanelTab::Live,
@@ -579,6 +581,7 @@ fn model(app: &App) -> Model {
         shader_rx,
         global_config,
         presets,
+        smoothed_preset,
         smoothing_speed: 0.05,
         colour_channels,
         buttons: Default::default(),
@@ -925,7 +928,7 @@ pub fn rebuild_led_shader_inputs(led_layout: &conf::LedLayout) -> Vec<CachedLedS
 fn build_led_worker_input_state(
     app_time: f32,
     global_config: &GlobalConfig,
-    presets: &conf::Presets,
+    preset: &conf::Preset,
     audio_input: &audio_input::AudioInput,
     colour_channels: [f32; 3],
     left_panel_tab: gui::LeftPanelTab,
@@ -943,7 +946,7 @@ fn build_led_worker_input_state(
             fade_to_black_led: global_config.fade_to_black.led,
             preset_lerp_secs: global_config.preset_lerp_secs,
             led_layout: global_config.led_layout.clone(),
-            preset: presets.selected().clone(),
+            preset: preset.clone(),
             resolved_layout,
         },
         colour_channels,
@@ -1077,7 +1080,7 @@ fn queue_led_worker_update(app: &App, model: &mut Model) {
         shared_input.latest_state = build_led_worker_input_state(
             app.time,
             &model.global_config,
-            &model.presets,
+            &model.smoothed_preset,
             &model.audio_input,
             model.colour_channels,
             model.left_panel_tab,
@@ -1091,6 +1094,90 @@ fn queue_led_worker_update(app: &App, model: &mut Model) {
             shared_input.pending_preset_change = Some(last_preset_change);
         }
     }
+}
+
+fn smooth_shader_params_toward(
+    shader: shader_shared::Shader,
+    current: ShaderParams,
+    target: ShaderParams,
+    smoothing_speed: f32,
+) -> ShaderParams {
+    let mut current = current;
+    let mut target = target;
+    let mut smoothed = target;
+
+    let current_params: &mut dyn gui::Params = gui::shader_params(shader, &mut current);
+    let target_params: &mut dyn gui::Params = gui::shader_params(shader, &mut target);
+    let smoothed_params: &mut dyn gui::Params = gui::shader_params(shader, &mut smoothed);
+
+    for ix in 0..target_params.param_count() {
+        let gui::ParamMut {
+            kind: current_kind, ..
+        } = current_params.param_mut(ix);
+        let gui::ParamMut {
+            kind: target_kind, ..
+        } = target_params.param_mut(ix);
+        let gui::ParamMut {
+            kind: smoothed_kind,
+            ..
+        } = smoothed_params.param_mut(ix);
+
+        match (current_kind, target_kind, smoothed_kind) {
+            (
+                gui::ParamKindMut::F32 { value: current, .. },
+                gui::ParamKindMut::F32 { value: target, .. },
+                gui::ParamKindMut::F32 {
+                    value: smoothed, ..
+                },
+            )
+            | (
+                gui::ParamKindMut::F32Range { value: current, .. },
+                gui::ParamKindMut::F32Range { value: target, .. },
+                gui::ParamKindMut::F32Range {
+                    value: smoothed, ..
+                },
+            ) => {
+                *smoothed = *current * (1.0 - smoothing_speed) + *target * smoothing_speed;
+            }
+            _ => {}
+        }
+    }
+
+    smoothed
+}
+
+fn update_smoothed_preset(model: &mut Model) {
+    let target = model.presets.selected().clone();
+    let should_reset = model.smoothed_preset.id != target.id
+        || model.smoothed_preset.shader_left != target.shader_left
+        || model.smoothed_preset.colourise != target.colourise
+        || model.smoothed_preset.shader_right != target.shader_right;
+
+    if should_reset {
+        model.smoothed_preset = target;
+        return;
+    }
+
+    let current = model.smoothed_preset.clone();
+    model.smoothed_preset = target.clone();
+    model.smoothed_preset.shader_params_left = smooth_shader_params_toward(
+        target.shader_left,
+        current.shader_params_left,
+        target.shader_params_left,
+        model.smoothing_speed,
+    );
+    model.smoothed_preset.shader_params_colourise = smooth_shader_params_toward(
+        target.colourise,
+        current.shader_params_colourise,
+        target.shader_params_colourise,
+        model.smoothing_speed,
+    );
+    model.smoothed_preset.shader_params_right = smooth_shader_params_toward(
+        target.shader_right,
+        current.shader_params_right,
+        target.shader_params_right,
+        model.smoothing_speed,
+    );
 }
 
 fn apply_led_worker_output(model: &mut Model) {
@@ -1817,6 +1904,8 @@ fn update(app: &App, model: &mut Model, update: Update) {
             midi_mapping: &mut model.midi_mapping,
             midi_learn: &mut model.midi_learn,
             midi_values: &mut model.midi_values,
+            smoothing_speed: &mut model.smoothing_speed,
+            smoothed_preset: &model.smoothed_preset,
             preview_left_image_id: model.preview_images.as_ref().map(|pi| pi.left_id),
             preview_right_image_id: model.preview_images.as_ref().map(|pi| pi.right_id),
             preview_colourise_image_id: model.preview_images.as_ref().map(|pi| pi.colourise_id),
@@ -1900,6 +1989,8 @@ fn update(app: &App, model: &mut Model, update: Update) {
 
     // Apply smoothed MIDI values to their destinations.
     apply_midi_values(model);
+
+    update_smoothed_preset(model);
 
     queue_led_worker_update(app, model);
 }

--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -78,6 +78,7 @@ struct Model {
     smoothed_preset: conf::Preset,
     smoothing_speed: f32,
     smoothed_master_speed: f32,
+    smoothed_phase_offset: f32,
     master_phase: f32,
     colour_channels: [f32; 3],
     buttons: HashMap<shader_shared::Button, ButtonState>,
@@ -202,6 +203,8 @@ struct LedWorkerConfig {
     fade_to_black_led: f32,
     preset_lerp_secs: f32,
     master_speed: f32,
+    phase_offset: f32,
+    phase_offset_mod_amount: f32,
     led_layout: conf::LedLayout,
     preset: conf::Preset,
     /// Resolved layout from MadMapper, if active.
@@ -558,6 +561,7 @@ fn model(app: &App) -> Model {
     let colour_channels = [1.0, 0.0, 1.0]; // R/H, G/S, B/V defaults
     let smoothed_preset = presets.selected().clone();
     let smoothed_master_speed = global_config.master_speed;
+    let smoothed_phase_offset = global_config.phase_offset;
 
     let resolved_layout = mad_project.as_ref().map(layout::resolve_from_mad_project);
 
@@ -565,6 +569,7 @@ fn model(app: &App) -> Model {
     let led_worker = LedWorker::new(build_led_worker_input_state(
         0.0,
         smoothed_master_speed,
+        smoothed_phase_offset,
         &global_config,
         &smoothed_preset,
         &audio_input,
@@ -589,6 +594,7 @@ fn model(app: &App) -> Model {
         smoothed_preset,
         smoothing_speed: 0.05,
         smoothed_master_speed,
+        smoothed_phase_offset,
         master_phase: 0.0,
         colour_channels,
         buttons: Default::default(),
@@ -935,6 +941,7 @@ pub fn rebuild_led_shader_inputs(led_layout: &conf::LedLayout) -> Vec<CachedLedS
 fn build_led_worker_input_state(
     app_time: f32,
     master_speed: f32,
+    phase_offset: f32,
     global_config: &GlobalConfig,
     preset: &conf::Preset,
     audio_input: &audio_input::AudioInput,
@@ -954,6 +961,8 @@ fn build_led_worker_input_state(
             fade_to_black_led: global_config.fade_to_black.led,
             preset_lerp_secs: global_config.preset_lerp_secs,
             master_speed,
+            phase_offset,
+            phase_offset_mod_amount: global_config.phase_offset_mod_amount,
             led_layout: global_config.led_layout.clone(),
             preset: preset.clone(),
             resolved_layout,
@@ -1002,6 +1011,21 @@ fn apply_midi_values(model: &mut Model) {
         match target {
             MidiTarget::SmoothingSpeed => {
                 model.smoothing_speed = map_range(v, 0.0, 1.0, 0.0008, 0.08);
+            }
+            MidiTarget::MasterSpeed => {
+                model.global_config.master_speed = v;
+            }
+            MidiTarget::PhaseOffset => {
+                model.global_config.phase_offset = map_range(
+                    v,
+                    0.0,
+                    1.0,
+                    gui::GLOBAL_PHASE_OFFSET_MIN,
+                    gui::GLOBAL_PHASE_OFFSET_MAX,
+                );
+            }
+            MidiTarget::PhaseOffsetMod => {
+                model.global_config.phase_offset_mod_amount = v;
             }
             MidiTarget::FadeToBlack => {
                 model.global_config.fade_to_black.led = v;
@@ -1089,6 +1113,7 @@ fn queue_led_worker_update(_app: &App, model: &mut Model) {
         shared_input.latest_state = build_led_worker_input_state(
             model.master_phase,
             model.smoothed_master_speed,
+            model.smoothed_phase_offset,
             &model.global_config,
             &model.smoothed_preset,
             &model.audio_input,
@@ -1194,6 +1219,10 @@ fn update_smoothed_master_speed(model: &mut Model) {
     let target = model.global_config.master_speed;
     model.smoothed_master_speed = model.smoothed_master_speed * (1.0 - model.smoothing_speed)
         + target * model.smoothing_speed;
+
+    let phase_offset_target = model.global_config.phase_offset;
+    model.smoothed_phase_offset = model.smoothed_phase_offset * (1.0 - model.smoothing_speed)
+        + phase_offset_target * model.smoothing_speed;
 }
 
 fn apply_led_worker_output(model: &mut Model) {
@@ -1710,8 +1739,13 @@ fn preset_uniforms(state: &LedWorkerInputState, preset: &conf::Preset) -> Unifor
             (button, state)
         })
         .collect();
-    let time =
-        state.app_time + state.snapshot_at.elapsed().as_secs_f32() * state.config.master_speed;
+    let phase_offset = (state.config.phase_offset
+        + (state.audio_envelope * state.config.phase_offset_mod_amount)
+        - (state.config.phase_offset_mod_amount / 2.0))
+        .clamp(gui::GLOBAL_PHASE_OFFSET_MIN, gui::GLOBAL_PHASE_OFFSET_MAX);
+    let time = state.app_time
+        + state.snapshot_at.elapsed().as_secs_f32() * state.config.master_speed
+        + phase_offset;
     Uniforms {
         time,
         resolution: layout::shader_resolution(led_layout),
@@ -1923,6 +1957,7 @@ fn update(app: &App, model: &mut Model, update: Update) {
             midi_values: &mut model.midi_values,
             smoothing_speed: &mut model.smoothing_speed,
             smoothed_master_speed: model.smoothed_master_speed,
+            smoothed_phase_offset: model.smoothed_phase_offset,
             smoothed_preset: &model.smoothed_preset,
             preview_left_image_id: model.preview_images.as_ref().map(|pi| pi.left_id),
             preview_right_image_id: model.preview_images.as_ref().map(|pi| pi.right_id),

--- a/cohen_gig/src/midi/mapping.rs
+++ b/cohen_gig/src/midi/mapping.rs
@@ -7,9 +7,13 @@ pub const MAX_SHADER_PARAMS: u8 = 6;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MidiTarget {
+    // Global
+    SmoothingSpeed,
+    MasterSpeed,
+    PhaseOffset,
+    PhaseOffsetMod,
     // Blending/Mix
     LeftRightMix,
-    SmoothingSpeed,
     FadeToBlack,
     // Audio
     AudioGain,
@@ -33,9 +37,13 @@ pub enum MidiTarget {
 impl MidiTarget {
     pub fn all() -> Vec<MidiTarget> {
         let mut targets = vec![
+            // Global
+            MidiTarget::SmoothingSpeed,
+            MidiTarget::MasterSpeed,
+            MidiTarget::PhaseOffset,
+            MidiTarget::PhaseOffsetMod,
             // Blending/Mix
             MidiTarget::LeftRightMix,
-            MidiTarget::SmoothingSpeed,
             MidiTarget::FadeToBlack,
             // Audio
             MidiTarget::AudioGain,
@@ -68,8 +76,11 @@ impl MidiTarget {
 
     pub fn label(&self) -> &'static str {
         match self {
-            MidiTarget::LeftRightMix => "Left/Right Mix",
             MidiTarget::SmoothingSpeed => "Smoothing Speed",
+            MidiTarget::MasterSpeed => "Global Speed",
+            MidiTarget::PhaseOffset => "Phase Offset",
+            MidiTarget::PhaseOffsetMod => "Phase Offset Mod",
+            MidiTarget::LeftRightMix => "Left/Right Mix",
             MidiTarget::FadeToBlack => "Fade to Black",
             MidiTarget::AudioGain => "Audio Gain",
             MidiTarget::AudioThreshold => "Audio Threshold",
@@ -103,9 +114,11 @@ impl MidiTarget {
 
     pub fn category(&self) -> &'static str {
         match self {
-            MidiTarget::LeftRightMix | MidiTarget::SmoothingSpeed | MidiTarget::FadeToBlack => {
-                "Blending/Mix"
-            }
+            MidiTarget::SmoothingSpeed
+            | MidiTarget::MasterSpeed
+            | MidiTarget::PhaseOffset
+            | MidiTarget::PhaseOffsetMod => "Global",
+            MidiTarget::LeftRightMix | MidiTarget::FadeToBlack => "Blending/Mix",
             MidiTarget::AudioGain
             | MidiTarget::AudioThreshold
             | MidiTarget::AudioAttack
@@ -122,6 +135,7 @@ impl MidiTarget {
 
     pub fn categories() -> &'static [&'static str] {
         &[
+            "Global",
             "Blending/Mix",
             "Audio",
             "Colour",

--- a/cohen_gig/src/mod_slider.rs
+++ b/cohen_gig/src/mod_slider.rs
@@ -7,6 +7,7 @@ const GAP: Scalar = 4.0;
 pub struct ModSlider<'a> {
     common: widget::CommonBuilder,
     value: f32,
+    smoothed_value: f32,
     mod_amount: f32,
     modulation: f32,
     min: f32,
@@ -31,10 +32,18 @@ widget_ids! {
 }
 
 impl<'a> ModSlider<'a> {
-    pub fn new(value: f32, mod_amount: f32, modulation: f32, min: f32, max: f32) -> Self {
+    pub fn new(
+        value: f32,
+        smoothed_value: f32,
+        mod_amount: f32,
+        modulation: f32,
+        min: f32,
+        max: f32,
+    ) -> Self {
         ModSlider {
             common: widget::CommonBuilder::default(),
             value,
+            smoothed_value,
             mod_amount,
             modulation,
             min,
@@ -83,6 +92,7 @@ impl<'a> Widget for ModSlider<'a> {
         } = args;
         let ModSlider {
             value,
+            smoothed_value,
             mod_amount,
             modulation,
             min,
@@ -130,7 +140,7 @@ impl<'a> Widget for ModSlider<'a> {
 
         // Mod bar: sits just above the slider, shows final output.
         let cur_mod = new_mod.unwrap_or(mod_amount);
-        let cur_val = new_value.unwrap_or(value);
+        let cur_val = smoothed_value;
         let offset = (modulation * cur_mod) - (cur_mod / 2.0);
         let final_val = (cur_val + offset).max(min).min(max);
         let final_norm = ((final_val - min) / (max - min)) as Scalar;

--- a/cohen_gig/src/mod_slider.rs
+++ b/cohen_gig/src/mod_slider.rs
@@ -15,6 +15,15 @@ pub struct ModSlider<'a> {
     label: &'a str,
 }
 
+pub struct SmoothedSlider<'a> {
+    common: widget::CommonBuilder,
+    value: f32,
+    smoothed_value: f32,
+    min: f32,
+    max: f32,
+    label: &'a str,
+}
+
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Style;
 
@@ -59,6 +68,33 @@ impl<'a> ModSlider<'a> {
 }
 
 impl<'a> widget::Common for ModSlider<'a> {
+    fn common(&self) -> &widget::CommonBuilder {
+        &self.common
+    }
+    fn common_mut(&mut self) -> &mut widget::CommonBuilder {
+        &mut self.common
+    }
+}
+
+impl<'a> SmoothedSlider<'a> {
+    pub fn new(value: f32, smoothed_value: f32, min: f32, max: f32) -> Self {
+        SmoothedSlider {
+            common: widget::CommonBuilder::default(),
+            value,
+            smoothed_value,
+            min,
+            max,
+            label: "",
+        }
+    }
+
+    pub fn label(mut self, label: &'a str) -> Self {
+        self.label = label;
+        self
+    }
+}
+
+impl<'a> widget::Common for SmoothedSlider<'a> {
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
     }
@@ -171,5 +207,78 @@ impl<'a> Widget for ModSlider<'a> {
         } else {
             None
         }
+    }
+}
+
+impl<'a> Widget for SmoothedSlider<'a> {
+    type State = State;
+    type Style = Style;
+    type Event = Option<f32>;
+
+    fn init_state(&self, id_gen: widget::id::Generator) -> Self::State {
+        State {
+            ids: Ids::new(id_gen),
+        }
+    }
+
+    fn style(&self) -> Self::Style {
+        Style
+    }
+
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
+        let widget::UpdateArgs {
+            id,
+            state,
+            rect,
+            ui,
+            ..
+        } = args;
+        let SmoothedSlider {
+            value,
+            smoothed_value,
+            min,
+            max,
+            label,
+            ..
+        } = self;
+
+        let slider_h = rect.h() - MOD_BAR_H - 2.0;
+        let slider_w = rect.w();
+        let slider_cx = rect.x();
+        let slider_cy = rect.bottom() + slider_h / 2.0;
+        let slider_left = rect.left();
+
+        let new_value = widget::Slider::new(value, min, max)
+            .w_h(slider_w, slider_h)
+            .x_y(slider_cx, slider_cy)
+            .label(label)
+            .label_font_size(11)
+            .label_color(color::WHITE)
+            .color(color::rgb(0.176, 0.513, 0.639))
+            .border(0.0)
+            .parent(id)
+            .set(state.ids.slider, ui);
+
+        let final_norm = ((smoothed_value - min) / (max - min)).clamp(0.0, 1.0) as Scalar;
+        let bar_y = slider_cy + slider_h / 2.0 + MOD_BAR_H / 2.0 + 1.0;
+
+        widget::Rectangle::fill([slider_w, MOD_BAR_H])
+            .x_y(slider_cx, bar_y)
+            .color(color::rgb(0.08, 0.08, 0.08))
+            .parent(id)
+            .graphics_for(id)
+            .set(state.ids.mod_bar_bg, ui);
+
+        let fill_w = (final_norm * slider_w).max(0.0);
+        if fill_w > 0.5 {
+            widget::Rectangle::fill([fill_w, MOD_BAR_H])
+                .x_y(slider_left + fill_w / 2.0, bar_y)
+                .color(color::rgb(0.2, 0.8, 0.4))
+                .parent(id)
+                .graphics_for(id)
+                .set(state.ids.mod_bar, ui);
+        }
+
+        new_value
     }
 }


### PR DESCRIPTION
## What changed

This PR adds global animation controls in the live UI and exposes them to MIDI mapping.

The new global controls are:
- `Smoothing Speed`
- `Master Speed`
- `Phase Offset`
- `Phase Offset Mod`

It also updates the shader-control behavior so continuous controls can keep their target value in the UI while the rendered value smooths toward that target.

## Why

The goal is to make whole-scene animation motion easier to shape in performance:
- slow or freeze all animation globally
- smooth control changes instead of hard jumps
- use the envelope follower to gently accelerate and decelerate the overall phase
- map those global controls directly from MIDI hardware

## Impact

Performers can now:
- adjust smoothing from the UI
- slow down or freeze the global animation phase with `Master Speed`
- apply a global phase offset with audio-envelope modulation for smooth tempo-like movement
- MIDI-map the global controls under their own `Global` category in the MIDI tab

## Validation

- `cargo check`
