### PR TITLE
Queue overlapping preset transitions

### DIFF
--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -24,6 +24,8 @@ pub const WIDGET_W: Scalar = COLUMN_W;
 pub const HALF_WIDGET_W: Scalar = WIDGET_W * 0.5 - PAD * 0.25;
 pub const GLOBAL_PHASE_OFFSET_MIN: f32 = -0.2;
 pub const GLOBAL_PHASE_OFFSET_MAX: f32 = 0.2;
+pub const PRESET_LERP_MAX_SECS: f32 = 60.0;
+pub const PRESET_LERP_SLIDER_EXPONENT: f32 = 2.0;
 pub const BUTTON_COLOR: Color = Color::Rgba(0.11, 0.39, 0.4, 1.0); // teal
 pub const TEXT_COLOR: Color = Color::Rgba(1.0, 1.0, 1.0, 1.0);
 pub const PRESET_LIST_COLOR: Color = Color::Rgba(0.16, 0.32, 0.6, 1.0); // blue
@@ -3048,13 +3050,14 @@ pub fn set_presets_widgets(
         .set(ids.presets_text, ui);
 
     let label = format!("Lerp Duration: {:.2} secs", global_config.preset_lerp_secs);
-    if let Some(v) = slider(global_config.preset_lerp_secs, 0.0, 10.0)
+    let slider_value = preset_lerp_secs_to_slider_value(global_config.preset_lerp_secs);
+    if let Some(v) = slider(slider_value, 0.0, 1.0)
         .down(10.0)
         .w_h(WIDGET_W, DEFAULT_WIDGET_H)
         .label(&label)
         .set(ids.presets_lerp_slider, ui)
     {
-        global_config.preset_lerp_secs = v;
+        global_config.preset_lerp_secs = preset_lerp_slider_value_to_secs(v);
     }
 
     for _click in button()
@@ -3463,6 +3466,16 @@ pub fn slider(val: f32, min: f32, max: f32) -> widget::Slider<'static, f32> {
         .rgb(0.176, 0.513, 0.639)
         .label_rgb(1.0, 1.0, 1.0)
         .border(0.0)
+}
+
+fn preset_lerp_secs_to_slider_value(secs: f32) -> f32 {
+    (secs / PRESET_LERP_MAX_SECS)
+        .clamp(0.0, 1.0)
+        .powf(1.0 / PRESET_LERP_SLIDER_EXPONENT)
+}
+
+fn preset_lerp_slider_value_to_secs(slider_value: f32) -> f32 {
+    PRESET_LERP_MAX_SECS * slider_value.clamp(0.0, 1.0).powf(PRESET_LERP_SLIDER_EXPONENT)
 }
 
 fn column_canvas(background: widget::Id) -> widget::Canvas<'static> {

--- a/cohen_gig/src/gui.rs
+++ b/cohen_gig/src/gui.rs
@@ -3037,7 +3037,7 @@ pub fn set_presets_widgets(
     presets: &mut crate::conf::Presets,
     preset_list_drag: &mut PresetListDragState,
     last_preset_change: &mut Option<crate::LastPresetChange>,
-    _led_colors: &LedColors,
+    led_colors: &LedColors,
     assets: &Path,
     hover_preview_request: &mut Option<crate::HoverPreviewRequest>,
     _hover_preview_state: &mut HoverPreviewState,
@@ -3235,6 +3235,7 @@ pub fn set_presets_widgets(
                     *last_preset_change = Some(crate::LastPresetChange {
                         started_at: std::time::Instant::now(),
                         preset: outgoing_preset,
+                        led_colors: led_colors.to_vec(),
                     });
                 }
             }

--- a/cohen_gig/src/main.rs
+++ b/cohen_gig/src/main.rs
@@ -109,6 +109,7 @@ struct Model {
 struct LastPresetChange {
     started_at: Instant,
     preset: conf::Preset,
+    led_colors: Vec<LinSrgb>,
 }
 
 #[derive(Clone)]
@@ -122,6 +123,7 @@ struct PresetTransitionState {
     preset: conf::Preset,
     led_colors: Vec<LinSrgb>,
     led_color_buffer: Vec<LinSrgb>,
+    lerp_amt: f32,
 }
 
 #[derive(Copy, Clone)]
@@ -164,7 +166,7 @@ struct LedWorker {
 
 struct LedWorkerSharedInput {
     latest_state: LedWorkerInputState,
-    pending_preset_change: Option<LastPresetChange>,
+    pending_preset_changes: Vec<LastPresetChange>,
     pending_shader: Option<Shader>,
     hover_preview_request: Option<HoverPreviewRequest>,
     shutdown: bool,
@@ -409,7 +411,7 @@ impl LedWorker {
     fn new(initial_state: LedWorkerInputState) -> Self {
         let shared_input = Arc::new(Mutex::new(LedWorkerSharedInput {
             latest_state: initial_state,
-            pending_preset_change: None,
+            pending_preset_changes: Vec::new(),
             pending_shader: None,
             hover_preview_request: None,
             shutdown: false,
@@ -1126,7 +1128,7 @@ fn queue_led_worker_update(_app: &App, model: &mut Model) {
         shared_input.hover_preview_request = model.hover_preview_request.clone();
 
         if let Some(last_preset_change) = model.last_preset_change.take() {
-            shared_input.pending_preset_change = Some(last_preset_change);
+            shared_input.pending_preset_changes.push(last_preset_change);
         }
     }
 }
@@ -1297,7 +1299,7 @@ struct LedWorkerRuntime {
     cached_led_layout: conf::LedLayout,
     /// True when currently using a MadMapper resolved layout.
     using_mad_layout: bool,
-    preset_transition: Option<PresetTransitionState>,
+    preset_transitions: Vec<PresetTransitionState>,
     dmx: DmxRuntime,
 }
 
@@ -1323,7 +1325,7 @@ impl LedWorkerRuntime {
             led_shader_inputs: shader_inputs,
             cached_led_layout: config.led_layout.clone(),
             using_mad_layout: using_mad,
-            preset_transition: None,
+            preset_transitions: Vec::new(),
             dmx: DmxRuntime {
                 source: None,
                 requested_interface_ip: None,
@@ -1367,7 +1369,7 @@ fn sync_led_worker_buffers(runtime: &mut LedWorkerRuntime, config: &LedWorkerCon
         runtime
             .led_outputs
             .resize(led_count, lin_srgb(0.0, 0.0, 0.0));
-        runtime.preset_transition = None;
+        runtime.preset_transitions.clear();
     }
     if source_changed || runtime.led_shader_inputs.len() != led_count {
         runtime.led_shader_inputs = match new_inputs {
@@ -1376,7 +1378,7 @@ fn sync_led_worker_buffers(runtime: &mut LedWorkerRuntime, config: &LedWorkerCon
         };
         runtime.cached_led_layout = config.led_layout.clone();
         runtime.using_mad_layout = now_mad;
-        runtime.preset_transition = None;
+        runtime.preset_transitions.clear();
     }
 }
 
@@ -1394,7 +1396,7 @@ fn run_led_worker(
     let mut frame_id = 0u64;
 
     loop {
-        let (state, pending_shader, pending_preset_change, hover_preview_request, shutdown) = {
+        let (state, pending_shader, pending_preset_changes, hover_preview_request, shutdown) = {
             let mut input = match shared_input.lock() {
                 Ok(input) => input,
                 Err(_) => break,
@@ -1402,7 +1404,7 @@ fn run_led_worker(
             (
                 input.latest_state.clone(),
                 input.pending_shader.take(),
-                input.pending_preset_change.take(),
+                std::mem::take(&mut input.pending_preset_changes),
                 input.hover_preview_request.clone(),
                 input.shutdown,
             )
@@ -1415,12 +1417,18 @@ fn run_led_worker(
         if let Some(shader) = pending_shader {
             runtime.shader = Some(shader);
         }
-        if let Some(last_preset_change) = pending_preset_change {
-            runtime.preset_transition = Some(PresetTransitionState {
+        for last_preset_change in pending_preset_changes {
+            let led_colors = if last_preset_change.led_colors.len() == runtime.led_colors.len() {
+                last_preset_change.led_colors
+            } else {
+                runtime.led_colors.clone()
+            };
+            runtime.preset_transitions.push(PresetTransitionState {
                 started_at: last_preset_change.started_at,
                 preset: last_preset_change.preset,
-                led_colors: runtime.led_colors.clone(),
+                led_colors,
                 led_color_buffer: black_led_buffer(runtime.led_colors.len()),
+                lerp_amt: 1.0,
             });
         }
 
@@ -1612,49 +1620,66 @@ fn render_led_worker_frame(
         );
     }
 
-    let mut clear_transition = state.config.preset_lerp_secs <= 0.0;
-    let (prev_output, lerp_amt) = match runtime.preset_transition.as_mut() {
-        None => (&[][..], 1.0),
-        Some(transition) => {
+    if state.config.preset_lerp_secs <= 0.0 {
+        runtime.preset_transitions.clear();
+    } else {
+        runtime.preset_transitions.retain_mut(|transition| {
             let elapsed_secs = transition.started_at.elapsed().as_secs_f32();
-            if elapsed_secs < state.config.preset_lerp_secs {
-                let transition_uniforms = preset_uniforms(state, &transition.preset);
-                render_preset_graph(
-                    shader,
-                    &runtime.led_shader_inputs,
-                    &transition_uniforms,
-                    &transition.led_colors,
-                    &mut transition.led_color_buffer,
-                );
-                std::mem::swap(&mut transition.led_colors, &mut transition.led_color_buffer);
-                (
-                    &transition.led_colors[..],
-                    ease_in_out((elapsed_secs / state.config.preset_lerp_secs).clamp(0.0, 1.0)),
-                )
-            } else {
-                clear_transition = true;
-                (&[][..], 1.0)
+            if elapsed_secs >= state.config.preset_lerp_secs {
+                return false;
             }
-        }
-    };
+
+            let transition_uniforms = preset_uniforms(state, &transition.preset);
+            render_preset_graph(
+                shader,
+                &runtime.led_shader_inputs,
+                &transition_uniforms,
+                &transition.led_colors,
+                &mut transition.led_color_buffer,
+            );
+            std::mem::swap(&mut transition.led_colors, &mut transition.led_color_buffer);
+            transition.lerp_amt =
+                ease_in_out((elapsed_secs / state.config.preset_lerp_secs).clamp(0.0, 1.0));
+            true
+        });
+    }
 
     let ftb = state.config.fade_to_black_led;
     let l_ftb = lin_srgb(ftb, ftb, ftb);
-    runtime
-        .led_outputs
-        .par_iter_mut()
-        .zip(runtime.led_colors.par_iter())
-        .enumerate()
-        .for_each(|(i, (output, &colour))| {
-            let new = colour * l_ftb;
-            *output = match prev_output.get(i) {
-                None => new,
-                Some(prev) => prev.lerp(&new, lerp_amt),
-            };
-        });
+    if let Some(oldest_transition) = runtime.preset_transitions.first() {
+        runtime
+            .led_outputs
+            .par_iter_mut()
+            .zip(oldest_transition.led_colors.par_iter())
+            .for_each(|(output, &colour)| {
+                *output = colour * l_ftb;
+            });
 
-    if clear_transition {
-        runtime.preset_transition = None;
+        for transition_ix in 0..runtime.preset_transitions.len() {
+            let lerp_amt = runtime.preset_transitions[transition_ix].lerp_amt;
+            let next_colours = runtime
+                .preset_transitions
+                .get(transition_ix + 1)
+                .map(|transition| transition.led_colors.as_slice())
+                .unwrap_or(runtime.led_colors.as_slice());
+
+            runtime
+                .led_outputs
+                .par_iter_mut()
+                .zip(next_colours.par_iter())
+                .for_each(|(output, &next_colour)| {
+                    let next_colour = next_colour * l_ftb;
+                    *output = output.lerp(&next_colour, lerp_amt);
+                });
+        }
+    } else {
+        runtime
+            .led_outputs
+            .par_iter_mut()
+            .zip(runtime.led_colors.par_iter())
+            .for_each(|(output, &colour)| {
+                *output = colour * l_ftb;
+            });
     }
 
     update_led_worker_dmx(state, runtime);


### PR DESCRIPTION
## Summary
- replace the single preset transition slot with an ordered queue of active transition layers
- snapshot the outgoing preset's current LED state when a new preset is selected so it can keep animating while it fades out
- compose queued transition layers sequentially so multiple rapid preset clicks can overlap instead of cutting each other off

## Why
Switching presets during an active interpolation previously replaced the only tracked transition state. That caused the old shader to be cut off immediately instead of finishing its fade. With a long lerp duration, rapid preset changes should be able to stack and play through naturally.

## Impact
Preset changes now support overlapping fade chains, so triggering several presets in quick succession preserves each preset's fade-out while newer presets fade in.

## Validation
- `cargo check`